### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @bogdandrutu @pjanotti @flands @songy23
+* @bogdandrutu @pjanotti @flands @songy23 @tigrannajaryan


### PR DESCRIPTION
I am listed as a Maintainer here https://github.com/open-telemetry/community/blob/master/community-members.md#agent-and-collector but I am not in the CODEOWNERS file. I assume Maintainers should be all listed in CODEOWNERS.