### PR TITLE
Introduce optional memory ballast

### DIFF
--- a/cmd/occollector/app/builder/builder.go
+++ b/cmd/occollector/app/builder/builder.go
@@ -39,6 +39,7 @@ const (
 	zipkinScribeReceiverFlg     = "receive-zipkin-scribe"
 	loggingExporterFlg          = "logging-exporter"
 	useTailSamplingAlwaysSample = "tail-sampling-always-sample"
+	memBallastFlag              = "mem-ballast-size-mib"
 )
 
 // Flags adds flags related to basic building of the collector application to the given flagset.
@@ -55,6 +56,9 @@ func Flags(flags *flag.FlagSet) {
 	flags.Bool(loggingExporterFlg, false, "Flag to add a logging exporter (combine with log level DEBUG to log incoming spans)")
 	flags.Bool(useTailSamplingAlwaysSample, false, "Flag to use a tail-based sampling processor with an always sample policy, "+
 		"unless tail sampling setting is present on configuration file.")
+	flags.Uint(memBallastFlag, 0,
+		fmt.Sprintf("Flag to specify size of memory (MiB) ballast to set. Ballast is not used when this is not specified. "+
+			"default settings: 0"))
 }
 
 // GetConfigFile gets the config file from the config file flag.
@@ -70,6 +74,11 @@ func LoggingExporterEnabled(v *viper.Viper) bool {
 // DebugTailSamplingEnabled returns true if the debug processor is enabled, and false otherwise
 func DebugTailSamplingEnabled(v *viper.Viper) bool {
 	return v.GetBool(useTailSamplingAlwaysSample)
+}
+
+// MemBallastSize returns the size of memory ballast to use in MBs
+func MemBallastSize(v *viper.Viper) int {
+	return v.GetInt(memBallastFlag)
 }
 
 // JaegerReceiverCfg holds configuration for Jaeger receivers.

--- a/cmd/occollector/app/collector/telemetry.go
+++ b/cmd/occollector/app/collector/telemetry.go
@@ -53,7 +53,7 @@ func telemetryFlags(flags *flag.FlagSet) {
 	flags.Uint(metricsPortCfg, 8888, "Port exposing collector telemetry.")
 }
 
-func (tel *appTelemetry) init(asyncErrorChannel chan<- error, v *viper.Viper, logger *zap.Logger) error {
+func (tel *appTelemetry) init(asyncErrorChannel chan<- error, ballastSizeBytes uint64, v *viper.Viper, logger *zap.Logger) error {
 	level, err := telemetry.ParseLevel(v.GetString(metricsLevelCfg))
 	if err != nil {
 		log.Fatalf("Failed to parse metrics level: %v", err)
@@ -70,7 +70,7 @@ func (tel *appTelemetry) init(asyncErrorChannel chan<- error, v *viper.Viper, lo
 	views = append(views, nodebatcher.MetricViews(level)...)
 	views = append(views, observability.AllViews...)
 	views = append(views, tailsampling.SamplingProcessorMetricViews(level)...)
-	processMetricsViews := telemetry.NewProcessMetricsViews()
+	processMetricsViews := telemetry.NewProcessMetricsViews(ballastSizeBytes)
 	views = append(views, processMetricsViews.Views()...)
 	tel.views = views
 	if err := view.Register(views...); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/go-cmp v0.3.0
 	github.com/gorilla/mux v1.6.2
 	github.com/grpc-ecosystem/grpc-gateway v1.8.5
+	github.com/guillermo/go.procstat v0.0.0-20131123175440-34c2813d2e7f
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jaegertracing/jaeger v1.9.0
 	github.com/omnition/scribe-go v0.0.0-20190131012523-9e3c68f31124

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.6.3/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpg
 github.com/grpc-ecosystem/grpc-gateway v1.8.5 h1:2+KSC78XiO6Qy0hIjfc1OD9H+hsaJdJlb8Kqsd41CTE=
 github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
+github.com/guillermo/go.procstat v0.0.0-20131123175440-34c2813d2e7f h1:5qK7cub9F9wqib56+0HZlXgPn24GtmEVRoETcwQoOyA=
+github.com/guillermo/go.procstat v0.0.0-20131123175440-34c2813d2e7f/go.mod h1:ovoU5+mwafQ5XoEAuIEA9EMocbfVJ0vDacPD67dpL4k=
 github.com/hashicorp/consul v0.0.0-20180615161029-bed22a81e9fd h1:auIpcMc3+//R94n6tzTN+sJDiNvL3k5+Rus62AtvO4M=
 github.com/hashicorp/consul v0.0.0-20180615161029-bed22a81e9fd/go.mod h1:mFrjN1mfidgJfYP1xrJCF+AfRhr6Eaqhb2+sfyn/OOI=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=


### PR DESCRIPTION
This change add an optional memory ballast to help with ease GC pressure
in high thoughput scenarios

- Added new CLI flag called `--mem-ballast-size-mib` which represents
the size of memory ballast to use in MiB. Omitting the value or setting
it to zero does not set the ballast.

- Updated process telemetry code to account for the ballast and report
memory usage statistics after subtracting the ballast size. I'm not sure
if this makes sense in every scenario. If not, we can add another flag
to disable the behaviour. Another option is to add one more metric that
just exports the memory ballast size as a static number and then let
metric consumers to adjust the numbers.

https://blog.twitch.tv/go-memory-ballast-how-i-learnt-to-stop-worrying-and-love-the-heap-26c2462549a2

https://github.com/golang/go/issues/23044

## Effects
We've seen 30-50% increase in throughput and were able to considerably reduce the size of our collector cluster at Omnition.

![image](https://user-images.githubusercontent.com/46186/60025479-59b92c00-96b7-11e9-92ba-7872f3f0e4b7.png)
