### PR TITLE
Remove docker-collector makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,10 +102,6 @@ ifndef COMPONENT
 	$(error COMPONENT variable was not defined)
 endif
 
-.PHONY: docker-collector
-docker-collector:
-	COMPONENT=collector $(MAKE) docker-component
-
 .PHONY: docker-otelsvc
 docker-otelsvc:
 	COMPONENT=otelsvc $(MAKE) docker-component

--- a/demos/trace/README.md
+++ b/demos/trace/README.md
@@ -1,17 +1,19 @@
-# OpenCensus Service Demo
+# OpenTelemetry Service Demo
 
-*IMPORTANT:* This is a pre-released version of the OpenTelemetry Service.
-For now, please use the [OpenCensus Service](https://github.com/open-telemetry/opentelemetry-service).
+*IMPORTANT:* This is a pre-released version of the OpenTelemetry Service and does not yet
+implement full functionality required to run this demo.
 
-Typical flow of tracing data with OpenCensus Service: tracing data initially received by OC Agent
-and then sent OC Collector using OC data format. The OC Collector then sends the data to the
+For now, please use the [OpenCensus Service](https://github.com/census-instrumentation/opencensus-service).
+
+Typical flow of tracing data with OpenTelemetry Service: tracing data initially received by OpenTelemetry Agent
+and then sent to OpenTelemetry Collector using OC data format. The OpenTelemetry Collector then sends the data to the
 tracing backend, in this demo Jaeger and Zipkin.
 
-This demo uses `docker-compose` and runs against locally built docker images of OC service. In
+This demo uses `docker-compose` and runs against locally built docker images of OpenTelemetry Service. In
 order to build the docker images use the commands below from the root of the repo:
 
 ```shell
-make docker-collector
+make docker-otelsvc
 ```
 
 To run the demo, switch to the `demos/trace` folder and run:


### PR DESCRIPTION
We only need the unified docker-otelsvc. Having docker-collector in
the makefile is misleading and unnecessary.

Issue: https://github.com/open-telemetry/opentelemetry-service/issues/48