### PR TITLE
Cache dependencies on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
+cache:
+  directories:
+    - /home/travis/gopath/pkg/mod
 
 go_import_path: github.com/open-telemetry/opentelemetry-service
 
@@ -10,6 +13,7 @@ env:
     GO111MODULE=on
 
 install:
+  - go mod download
   - make install-tools
 
 script:


### PR DESCRIPTION
This change will cache Go mod dependencies on Travis CI and speed up
builds by a couple of minutes