### PR TITLE
Move ReceiverFactory to "receiver" package.

### DIFF
--- a/cmd/occollector/app/builder/exporters_builder.go
+++ b/cmd/occollector/app/builder/exporters_builder.go
@@ -170,7 +170,7 @@ func (eb *ExportersBuilder) buildExporter(
 		// Traces data type is required. Create a trace exporter based on config.
 		tc, stopFunc, err := factory.CreateTraceExporter(eb.logger, config)
 		if err != nil {
-			if err == factories.ErrDataTypeIsNotSupported {
+			if err == models.ErrDataTypeIsNotSupported {
 				// Could not create because this exporter does not support this data type.
 				return nil, typeMismatchErr(config, requirement.requiredBy, models.TracesDataType)
 			}
@@ -185,7 +185,7 @@ func (eb *ExportersBuilder) buildExporter(
 		// Metrics data type is required. Create a trace exporter based on config.
 		mc, stopFunc, err := factory.CreateMetricsExporter(eb.logger, config)
 		if err != nil {
-			if err == factories.ErrDataTypeIsNotSupported {
+			if err == models.ErrDataTypeIsNotSupported {
 				// Could not create because this exporter does not support this data type.
 				return nil, typeMismatchErr(config, requirement.requiredBy, models.MetricsDataType)
 			}

--- a/configv2/configv2.go
+++ b/configv2/configv2.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-service/factories"
 	"github.com/open-telemetry/opentelemetry-service/models"
+	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
 
 // These are errors that can be returned by Load(). Note that error codes are not part
@@ -181,7 +182,7 @@ func loadReceivers(v *viper.Viper) (models.Receivers, error) {
 		}
 
 		// Find receiver factory based on "type" that we read from config source
-		factory := factories.GetReceiverFactory(typeStr)
+		factory := receiver.GetReceiverFactory(typeStr)
 		if factory == nil {
 			return nil, &configError{
 				code: errUnknownReceiverType,

--- a/configv2/example_factories.go
+++ b/configv2/example_factories.go
@@ -49,7 +49,7 @@ func (f *ExampleReceiverFactory) Type() string {
 }
 
 // CustomUnmarshaler returns nil because we don't need custom unmarshaling for this factory.
-func (f *ExampleReceiverFactory) CustomUnmarshaler() factories.CustomUnmarshaler {
+func (f *ExampleReceiverFactory) CustomUnmarshaler() receiver.CustomUnmarshaler {
 	return nil
 }
 
@@ -73,7 +73,7 @@ func (f *ExampleReceiverFactory) CreateTraceReceiver(
 	nextConsumer consumer.TraceConsumer,
 ) (receiver.TraceReceiver, error) {
 	if cfg.(*ExampleReceiver).FailTraceCreation {
-		return nil, factories.ErrDataTypeIsNotSupported
+		return nil, models.ErrDataTypeIsNotSupported
 	}
 	return &ExampleReceiverProducer{TraceConsumer: nextConsumer}, nil
 }
@@ -85,7 +85,7 @@ func (f *ExampleReceiverFactory) CreateMetricsReceiver(
 	nextConsumer consumer.MetricsConsumer,
 ) (receiver.MetricsReceiver, error) {
 	if cfg.(*ExampleReceiver).FailMetricsCreation {
-		return nil, factories.ErrDataTypeIsNotSupported
+		return nil, models.ErrDataTypeIsNotSupported
 	}
 	return &ExampleReceiverProducer{MetricsConsumer: nextConsumer}, nil
 }
@@ -181,7 +181,7 @@ func (f *MultiProtoReceiverFactory) Type() string {
 }
 
 // CustomUnmarshaler returns nil because we don't need custom unmarshaling for this factory.
-func (f *MultiProtoReceiverFactory) CustomUnmarshaler() factories.CustomUnmarshaler {
+func (f *MultiProtoReceiverFactory) CustomUnmarshaler() receiver.CustomUnmarshaler {
 	return nil
 }
 
@@ -311,7 +311,7 @@ func (f *ExampleProcessorFactory) CreateTraceProcessor(
 	nextConsumer consumer.TraceConsumer,
 	cfg models.Processor,
 ) (processor.TraceProcessor, error) {
-	return nil, factories.ErrDataTypeIsNotSupported
+	return nil, models.ErrDataTypeIsNotSupported
 }
 
 // CreateMetricsProcessor creates a metrics processor based on this config.
@@ -320,13 +320,13 @@ func (f *ExampleProcessorFactory) CreateMetricsProcessor(
 	nextConsumer consumer.MetricsConsumer,
 	cfg models.Processor,
 ) (processor.MetricsProcessor, error) {
-	return nil, factories.ErrDataTypeIsNotSupported
+	return nil, models.ErrDataTypeIsNotSupported
 }
 
 // RegisterTestFactories registers example factories. This is only used by tests.
 func RegisterTestFactories() error {
-	_ = factories.RegisterReceiverFactory(&ExampleReceiverFactory{})
-	_ = factories.RegisterReceiverFactory(&MultiProtoReceiverFactory{})
+	_ = receiver.RegisterReceiverFactory(&ExampleReceiverFactory{})
+	_ = receiver.RegisterReceiverFactory(&MultiProtoReceiverFactory{})
 	_ = factories.RegisterExporterFactory(&ExampleExporterFactory{})
 	_ = factories.RegisterProcessorFactory(&ExampleProcessorFactory{})
 	return nil

--- a/exporter/opencensusexporter/factory.go
+++ b/exporter/opencensusexporter/factory.go
@@ -150,5 +150,5 @@ func (f *exporterFactory) CreateTraceExporter(logger *zap.Logger, config models.
 
 // CreateMetricsExporter creates a metrics exporter based on this config.
 func (f *exporterFactory) CreateMetricsExporter(logger *zap.Logger, cfg models.Exporter) (consumer.MetricsConsumer, factories.StopFunc, error) {
-	return nil, nil, factories.ErrDataTypeIsNotSupported
+	return nil, nil, models.ErrDataTypeIsNotSupported
 }

--- a/exporter/opencensusexporter/factory_test.go
+++ b/exporter/opencensusexporter/factory_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-service/factories"
 	"github.com/open-telemetry/opentelemetry-service/internal/compression"
+	"github.com/open-telemetry/opentelemetry-service/models"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -40,7 +41,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	_, _, err := factory.CreateMetricsExporter(zap.NewNop(), cfg)
-	assert.Error(t, err, factories.ErrDataTypeIsNotSupported)
+	assert.Error(t, err, models.ErrDataTypeIsNotSupported)
 }
 
 func TestCreateTraceExporter(t *testing.T) {

--- a/exporter/opencensusexporter/opencensusexporter_test.go
+++ b/exporter/opencensusexporter/opencensusexporter_test.go
@@ -20,8 +20,9 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/open-telemetry/opentelemetry-service/data"
 	"github.com/spf13/viper"
+
+	"github.com/open-telemetry/opentelemetry-service/data"
 )
 
 func TestOpenCensusTraceExportersFromViper(t *testing.T) {

--- a/factories/factories.go
+++ b/factories/factories.go
@@ -15,74 +15,14 @@
 package factories
 
 import (
-	"context"
-	"errors"
 	"fmt"
 
-	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
 	"github.com/open-telemetry/opentelemetry-service/models"
 	"github.com/open-telemetry/opentelemetry-service/processor"
-	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
-
-///////////////////////////////////////////////////////////////////////////////
-// Receiver factory and its registry.
-
-// ReceiverFactory is factory interface for receivers.
-type ReceiverFactory interface {
-	// Type gets the type of the Receiver created by this factory.
-	Type() string
-
-	// CreateDefaultConfig creates the default configuration for the Receiver.
-	CreateDefaultConfig() models.Receiver
-
-	// CustomUnmarshaler returns a custom unmarshaler for the configuration or nil if
-	// there is no need for custom unmarshaling. This is typically used if viper.Unmarshal()
-	// is not sufficient to unmarshal correctly.
-	CustomUnmarshaler() CustomUnmarshaler
-
-	// CreateTraceReceiver creates a trace receiver based on this config.
-	// If the receiver type does not support tracing or if the config is not valid
-	// error will be returned instead.
-	CreateTraceReceiver(ctx context.Context, logger *zap.Logger, cfg models.Receiver,
-		nextConsumer consumer.TraceConsumer) (receiver.TraceReceiver, error)
-
-	// CreateMetricsReceiver creates a metrics receiver based on this config.
-	// If the receiver type does not support metrics or if the config is not valid
-	// error will be returned instead.
-	CreateMetricsReceiver(logger *zap.Logger, cfg models.Receiver,
-		consumer consumer.MetricsConsumer) (receiver.MetricsReceiver, error)
-}
-
-// ErrDataTypeIsNotSupported can be returned by CreateTraceReceiver or
-// CreateMetricsReceiver if the particular telemetry data type is not supported
-// by the receiver.
-var ErrDataTypeIsNotSupported = errors.New("telemetry type is not supported")
-
-// CustomUnmarshaler is a function that un-marshals a viper data into a config struct
-// in a custom way.
-type CustomUnmarshaler func(v *viper.Viper, viperKey string, intoCfg interface{}) error
-
-// List of registered receiver factories.
-var receiverFactories = make(map[string]ReceiverFactory)
-
-// RegisterReceiverFactory registers a receiver factory.
-func RegisterReceiverFactory(factory ReceiverFactory) error {
-	if receiverFactories[factory.Type()] != nil {
-		panic(fmt.Sprintf("duplicate receiver factory %q", factory.Type()))
-	}
-
-	receiverFactories[factory.Type()] = factory
-	return nil
-}
-
-// GetReceiverFactory gets a receiver factory by type string.
-func GetReceiverFactory(typeStr string) ReceiverFactory {
-	return receiverFactories[typeStr]
-}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Exporter factory and its registry.

--- a/factories/factories_test.go
+++ b/factories/factories_test.go
@@ -15,7 +15,6 @@
 package factories
 
 import (
-	"context"
 	"testing"
 
 	"go.uber.org/zap"
@@ -23,75 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/consumer"
 	"github.com/open-telemetry/opentelemetry-service/models"
 	"github.com/open-telemetry/opentelemetry-service/processor"
-	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
-
-type ExampleReceiverFactory struct {
-}
-
-// Type gets the type of the Receiver config created by this factory.
-func (f *ExampleReceiverFactory) Type() string {
-	return "examplereceiver"
-}
-
-// CustomUnmarshaler returns nil because we don't need custom unmarshaling for this factory.
-func (f *ExampleReceiverFactory) CustomUnmarshaler() CustomUnmarshaler {
-	return nil
-}
-
-// CreateDefaultConfig creates the default configuration for the Receiver.
-func (f *ExampleReceiverFactory) CreateDefaultConfig() models.Receiver {
-	return nil
-}
-
-// CreateTraceReceiver creates a trace receiver based on this config.
-func (f *ExampleReceiverFactory) CreateTraceReceiver(
-	ctx context.Context,
-	logger *zap.Logger,
-	cfg models.Receiver,
-	nextConsumer consumer.TraceConsumer,
-) (receiver.TraceReceiver, error) {
-	// Not used for this test, just return nil
-	return nil, nil
-}
-
-// CreateMetricsReceiver creates a metrics receiver based on this config.
-func (f *ExampleReceiverFactory) CreateMetricsReceiver(
-	logger *zap.Logger,
-	cfg models.Receiver,
-	consumer consumer.MetricsConsumer,
-) (receiver.MetricsReceiver, error) {
-	// Not used for this test, just return nil
-	return nil, nil
-}
-
-func TestRegisterReceiverFactory(t *testing.T) {
-	f := ExampleReceiverFactory{}
-	err := RegisterReceiverFactory(&f)
-	if err != nil {
-		t.Fatalf("cannot register factory")
-	}
-
-	if &f != GetReceiverFactory(f.Type()) {
-		t.Fatalf("cannot find factory")
-	}
-
-	// Verify that attempt to register a factory with duplicate name panics
-	panicked := false
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				panicked = true
-			}
-		}()
-
-		err = RegisterReceiverFactory(&f)
-	}()
-
-	if !panicked {
-		t.Fatalf("must panic on double registration")
-	}
-}
 
 type ExampleExporterFactory struct {
 }
@@ -163,7 +94,7 @@ func (f *ExampleProcessorFactory) CreateTraceProcessor(
 	nextConsumer consumer.TraceConsumer,
 	cfg models.Processor,
 ) (processor.TraceProcessor, error) {
-	return nil, ErrDataTypeIsNotSupported
+	return nil, models.ErrDataTypeIsNotSupported
 }
 
 // CreateMetricsProcessor creates a metrics processor based on this config.
@@ -172,7 +103,7 @@ func (f *ExampleProcessorFactory) CreateMetricsProcessor(
 	nextConsumer consumer.MetricsConsumer,
 	cfg models.Processor,
 ) (processor.MetricsProcessor, error) {
-	return nil, ErrDataTypeIsNotSupported
+	return nil, models.ErrDataTypeIsNotSupported
 }
 
 func TestRegisterProcessorFactory(t *testing.T) {

--- a/internal/collector/processor/nodebatcher/factory.go
+++ b/internal/collector/processor/nodebatcher/factory.go
@@ -101,5 +101,5 @@ func (f *processorFactory) CreateMetricsProcessor(
 	nextConsumer consumer.MetricsConsumer,
 	cfg models.Processor,
 ) (processor.MetricsProcessor, error) {
-	return nil, factories.ErrDataTypeIsNotSupported
+	return nil, models.ErrDataTypeIsNotSupported
 }

--- a/internal/collector/processor/queued/factory.go
+++ b/internal/collector/processor/queued/factory.go
@@ -75,5 +75,5 @@ func (f *processorFactory) CreateMetricsProcessor(
 	nextConsumer consumer.MetricsConsumer,
 	cfg models.Processor,
 ) (processor.MetricsProcessor, error) {
-	return nil, factories.ErrDataTypeIsNotSupported
+	return nil, models.ErrDataTypeIsNotSupported
 }

--- a/models/commonerrors.go
+++ b/models/commonerrors.go
@@ -1,0 +1,22 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import "errors"
+
+// ErrDataTypeIsNotSupported can be returned by receiver, exporter or processor
+// factory methods that create the entity if the particular telemetry
+// data type is not supported by the receiver, exporter or processor.
+var ErrDataTypeIsNotSupported = errors.New("telemetry type is not supported")

--- a/processor/addattributesprocessor/factory.go
+++ b/processor/addattributesprocessor/factory.go
@@ -66,5 +66,5 @@ func (f *processorFactory) CreateMetricsProcessor(
 	nextConsumer consumer.MetricsConsumer,
 	cfg models.Processor,
 ) (processor.MetricsProcessor, error) {
-	return nil, factories.ErrDataTypeIsNotSupported
+	return nil, models.ErrDataTypeIsNotSupported
 }

--- a/receiver/factories_test.go
+++ b/receiver/factories_test.go
@@ -1,0 +1,92 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receiver
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-service/consumer"
+	"github.com/open-telemetry/opentelemetry-service/models"
+)
+
+type ExampleReceiverFactory struct {
+}
+
+// Type gets the type of the Receiver config created by this factory.
+func (f *ExampleReceiverFactory) Type() string {
+	return "examplereceiver"
+}
+
+// CustomUnmarshaler returns nil because we don't need custom unmarshaling for this factory.
+func (f *ExampleReceiverFactory) CustomUnmarshaler() CustomUnmarshaler {
+	return nil
+}
+
+// CreateDefaultConfig creates the default configuration for the Receiver.
+func (f *ExampleReceiverFactory) CreateDefaultConfig() models.Receiver {
+	return nil
+}
+
+// CreateTraceReceiver creates a trace receiver based on this config.
+func (f *ExampleReceiverFactory) CreateTraceReceiver(
+	ctx context.Context,
+	logger *zap.Logger,
+	cfg models.Receiver,
+	nextConsumer consumer.TraceConsumer,
+) (TraceReceiver, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+// CreateMetricsReceiver creates a metrics receiver based on this config.
+func (f *ExampleReceiverFactory) CreateMetricsReceiver(
+	logger *zap.Logger,
+	cfg models.Receiver,
+	consumer consumer.MetricsConsumer,
+) (MetricsReceiver, error) {
+	// Not used for this test, just return nil
+	return nil, nil
+}
+
+func TestRegisterReceiverFactory(t *testing.T) {
+	f := ExampleReceiverFactory{}
+	err := RegisterReceiverFactory(&f)
+	if err != nil {
+		t.Fatalf("cannot register factory")
+	}
+
+	if &f != GetReceiverFactory(f.Type()) {
+		t.Fatalf("cannot find factory")
+	}
+
+	// Verify that attempt to register a factory with duplicate name panics
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+
+		err = RegisterReceiverFactory(&f)
+	}()
+
+	if !panicked {
+		t.Fatalf("must panic on double registration")
+	}
+}

--- a/receiver/factory.go
+++ b/receiver/factory.go
@@ -1,0 +1,74 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receiver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-service/consumer"
+	"github.com/open-telemetry/opentelemetry-service/models"
+)
+
+// Factory is factory interface for receivers.
+type Factory interface {
+	// Type gets the type of the Receiver created by this factory.
+	Type() string
+
+	// CreateDefaultConfig creates the default configuration for the Receiver.
+	CreateDefaultConfig() models.Receiver
+
+	// CustomUnmarshaler returns a custom unmarshaler for the configuration or nil if
+	// there is no need for custom unmarshaling. This is typically used if viper.Unmarshal()
+	// is not sufficient to unmarshal correctly.
+	CustomUnmarshaler() CustomUnmarshaler
+
+	// CreateTraceReceiver creates a trace receiver based on this config.
+	// If the receiver type does not support tracing or if the config is not valid
+	// error will be returned instead.
+	CreateTraceReceiver(ctx context.Context, logger *zap.Logger, cfg models.Receiver,
+		nextConsumer consumer.TraceConsumer) (TraceReceiver, error)
+
+	// CreateMetricsReceiver creates a metrics receiver based on this config.
+	// If the receiver type does not support metrics or if the config is not valid
+	// error will be returned instead.
+	CreateMetricsReceiver(logger *zap.Logger, cfg models.Receiver,
+		consumer consumer.MetricsConsumer) (MetricsReceiver, error)
+}
+
+// CustomUnmarshaler is a function that un-marshals a viper data into a config struct
+// in a custom way.
+type CustomUnmarshaler func(v *viper.Viper, viperKey string, intoCfg interface{}) error
+
+// List of registered receiver factories.
+var receiverFactories = make(map[string]Factory)
+
+// RegisterReceiverFactory registers a receiver factory.
+func RegisterReceiverFactory(factory Factory) error {
+	if receiverFactories[factory.Type()] != nil {
+		panic(fmt.Sprintf("duplicate receiver factory %q", factory.Type()))
+	}
+
+	receiverFactories[factory.Type()] = factory
+	return nil
+}
+
+// GetReceiverFactory gets a receiver factory by type string.
+func GetReceiverFactory(typeStr string) Factory {
+	return receiverFactories[typeStr]
+}

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -22,14 +22,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-service/configv2"
-	"github.com/open-telemetry/opentelemetry-service/factories"
 	"github.com/open-telemetry/opentelemetry-service/models"
+	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
 
 var _ = configv2.RegisterTestFactories()
 
 func TestLoadConfig(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 
 	config, err := configv2.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"))
 

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -26,12 +26,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/factories"
 	"github.com/open-telemetry/opentelemetry-service/models"
 	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
 
-var _ = factories.RegisterReceiverFactory(&receiverFactory{})
+var _ = receiver.RegisterReceiverFactory(&receiverFactory{})
 
 const (
 	// The value of "type" key in configuration.
@@ -56,7 +55,7 @@ func (f *receiverFactory) Type() string {
 }
 
 // CustomUnmarshaler returns nil because we don't need custom unmarshaling for this config.
-func (f *receiverFactory) CustomUnmarshaler() factories.CustomUnmarshaler {
+func (f *receiverFactory) CustomUnmarshaler() receiver.CustomUnmarshaler {
 	return nil
 }
 
@@ -132,7 +131,7 @@ func (f *receiverFactory) CreateMetricsReceiver(
 	cfg models.Receiver,
 	consumer consumer.MetricsConsumer,
 ) (receiver.MetricsReceiver, error) {
-	return nil, factories.ErrDataTypeIsNotSupported
+	return nil, models.ErrDataTypeIsNotSupported
 }
 
 // extract the port number from string in "address:port" format. If the

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -18,21 +18,21 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
-	"github.com/stretchr/testify/assert"
-
-	"github.com/open-telemetry/opentelemetry-service/factories"
+	"github.com/open-telemetry/opentelemetry-service/models"
+	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
 }
 
 func TestCreateReceiver(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 
 	tReceiver, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
@@ -40,12 +40,12 @@ func TestCreateReceiver(t *testing.T) {
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 
 	mReceiver, err := factory.CreateMetricsReceiver(zap.NewNop(), cfg, nil)
-	assert.Equal(t, err, factories.ErrDataTypeIsNotSupported)
+	assert.Equal(t, err, models.ErrDataTypeIsNotSupported)
 	assert.Nil(t, mReceiver)
 }
 
 func TestCreateNoEndpoints(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*ConfigV2)
 
@@ -56,7 +56,7 @@ func TestCreateNoEndpoints(t *testing.T) {
 }
 
 func TestCreateInvalidTChannelEndpoint(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*ConfigV2)
 
@@ -66,7 +66,7 @@ func TestCreateInvalidTChannelEndpoint(t *testing.T) {
 }
 
 func TestCreateNoPort(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*ConfigV2)
 
@@ -76,7 +76,7 @@ func TestCreateNoPort(t *testing.T) {
 }
 
 func TestCreateLargePort(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*ConfigV2)
 
@@ -86,7 +86,7 @@ func TestCreateLargePort(t *testing.T) {
 }
 
 func TestCreateNoProtocols(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*ConfigV2)
 

--- a/receiver/opencensusreceiver/config_test.go
+++ b/receiver/opencensusreceiver/config_test.go
@@ -22,15 +22,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-service/configv2"
-	"github.com/open-telemetry/opentelemetry-service/factories"
 	"github.com/open-telemetry/opentelemetry-service/models"
+	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
 
 var _ = configv2.RegisterTestFactories()
 
 func TestLoadConfig(t *testing.T) {
 
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 
 	config, err := configv2.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"))
 

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -19,14 +19,13 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-service/factories"
 	"github.com/open-telemetry/opentelemetry-service/models"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
 	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
 
-var _ = factories.RegisterReceiverFactory(&receiverFactory{})
+var _ = receiver.RegisterReceiverFactory(&receiverFactory{})
 
 const (
 	// The value of "type" key in configuration.
@@ -43,7 +42,7 @@ func (f *receiverFactory) Type() string {
 }
 
 // CustomUnmarshaler returns nil because we don't need custom unmarshaling for this config.
-func (f *receiverFactory) CustomUnmarshaler() factories.CustomUnmarshaler {
+func (f *receiverFactory) CustomUnmarshaler() receiver.CustomUnmarshaler {
 	return nil
 }
 

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -22,18 +22,18 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/open-telemetry/opentelemetry-service/factories"
 	"github.com/open-telemetry/opentelemetry-service/internal/testutils"
+	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
 }
 
 func TestCreateReceiver(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 
 	config := cfg.(*ConfigV2)

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -23,14 +23,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-service/configv2"
-	"github.com/open-telemetry/opentelemetry-service/factories"
 	"github.com/open-telemetry/opentelemetry-service/models"
+	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
 
 var _ = configv2.RegisterTestFactories()
 
 func TestLoadConfig(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 
 	config, err := configv2.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"))
 

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -23,14 +23,13 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/factories"
 	"github.com/open-telemetry/opentelemetry-service/models"
 	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
 
 // This file implements config V2 for Prometheus receiver.
 
-var _ = factories.RegisterReceiverFactory(&ReceiverFactory{})
+var _ = receiver.RegisterReceiverFactory(&ReceiverFactory{})
 
 const (
 	// The value of "type" key in configuration.
@@ -47,7 +46,7 @@ func (f *ReceiverFactory) Type() string {
 }
 
 // CustomUnmarshaler returns custom unmarshaler for this config.
-func (f *ReceiverFactory) CustomUnmarshaler() factories.CustomUnmarshaler {
+func (f *ReceiverFactory) CustomUnmarshaler() receiver.CustomUnmarshaler {
 	return CustomUnmarshalerFunc
 }
 
@@ -104,7 +103,7 @@ func (f *ReceiverFactory) CreateTraceReceiver(
 	nextConsumer consumer.TraceConsumer,
 ) (receiver.TraceReceiver, error) {
 	// Prometheus does not support traces
-	return nil, factories.ErrDataTypeIsNotSupported
+	return nil, models.ErrDataTypeIsNotSupported
 }
 
 // CreateMetricsReceiver creates a metrics receiver based on provided config.

--- a/receiver/prometheusreceiver/factory_test.go
+++ b/receiver/prometheusreceiver/factory_test.go
@@ -20,23 +20,23 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-service/models"
+	"github.com/open-telemetry/opentelemetry-service/receiver"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/open-telemetry/opentelemetry-service/factories"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
 }
 
 func TestCreateReceiver(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 
 	tReceiver, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
-	assert.Equal(t, err, factories.ErrDataTypeIsNotSupported)
+	assert.Equal(t, err, models.ErrDataTypeIsNotSupported)
 	assert.Nil(t, tReceiver)
 
 	// The default config does not provide scrape_config so we expect that metrics receiver

--- a/receiver/zipkinreceiver/config_test.go
+++ b/receiver/zipkinreceiver/config_test.go
@@ -22,14 +22,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-service/configv2"
-	"github.com/open-telemetry/opentelemetry-service/factories"
 	"github.com/open-telemetry/opentelemetry-service/models"
+	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
 
 var _ = configv2.RegisterTestFactories()
 
 func TestLoadConfig(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 
 	config, err := configv2.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"))
 

--- a/receiver/zipkinreceiver/factory.go
+++ b/receiver/zipkinreceiver/factory.go
@@ -20,14 +20,13 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/factories"
 	"github.com/open-telemetry/opentelemetry-service/models"
 	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
 
 // This file implements factory for Zipkin receiver.
 
-var _ = factories.RegisterReceiverFactory(&ReceiverFactory{})
+var _ = receiver.RegisterReceiverFactory(&ReceiverFactory{})
 
 const (
 	// The value of "type" key in configuration.
@@ -46,7 +45,7 @@ func (f *ReceiverFactory) Type() string {
 }
 
 // CustomUnmarshaler returns nil because we don't need custom unmarshaling for this config.
-func (f *ReceiverFactory) CustomUnmarshaler() factories.CustomUnmarshaler {
+func (f *ReceiverFactory) CustomUnmarshaler() receiver.CustomUnmarshaler {
 	return nil
 }
 
@@ -79,5 +78,5 @@ func (f *ReceiverFactory) CreateMetricsReceiver(
 	cfg models.Receiver,
 	consumer consumer.MetricsConsumer,
 ) (receiver.MetricsReceiver, error) {
-	return nil, factories.ErrDataTypeIsNotSupported
+	return nil, models.ErrDataTypeIsNotSupported
 }

--- a/receiver/zipkinreceiver/factory_test.go
+++ b/receiver/zipkinreceiver/factory_test.go
@@ -23,11 +23,12 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/open-telemetry/opentelemetry-service/data"
-	"github.com/open-telemetry/opentelemetry-service/factories"
+	"github.com/open-telemetry/opentelemetry-service/models"
+	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
 }
@@ -38,7 +39,7 @@ type mockTraceConsumer struct {
 func (m *mockTraceConsumer) ConsumeTraceData(ctx context.Context, td data.TraceData) error { return nil }
 
 func TestCreateReceiver(t *testing.T) {
-	factory := factories.GetReceiverFactory(typeStr)
+	factory := receiver.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 
 	tReceiver, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, &mockTraceConsumer{})
@@ -46,6 +47,6 @@ func TestCreateReceiver(t *testing.T) {
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 
 	mReceiver, err := factory.CreateMetricsReceiver(zap.NewNop(), cfg, nil)
-	assert.Equal(t, err, factories.ErrDataTypeIsNotSupported)
+	assert.Equal(t, err, models.ErrDataTypeIsNotSupported)
 	assert.Nil(t, mReceiver)
 }


### PR DESCRIPTION
This is part 1 of 3 of the refactoring plan to eliminate factories.go
and move the content to corresponding packages (receiver, exporter, processor).