### PR TITLE
Refactor 2 private functions in zipkin exporters

### DIFF
--- a/exporter/zipkinexporter/zipkin.go
+++ b/exporter/zipkinexporter/zipkin.go
@@ -136,9 +136,9 @@ func lookupAttribute(node *commonpb.Node, key string) string {
 	return node.Attributes[key]
 }
 
-func zipkinEndpointFromNode(node *commonpb.Node, serviceName string, endpointType zipkinDirection) (*zipkinmodel.Endpoint, error) {
+func zipkinEndpointFromNode(node *commonpb.Node, serviceName string, endpointType zipkinDirection) *zipkinmodel.Endpoint {
 	if node == nil {
-		return nil, nil
+		return nil
 	}
 
 	// The data in the Attributes map was saved in the format
@@ -168,7 +168,7 @@ func zipkinEndpointFromNode(node *commonpb.Node, serviceName string, endpointTyp
 	port, _ := strconv.ParseUint(attributes[portKey], 10, 16)
 	if serviceName == "" && len(ip) == 0 && port == 0 {
 		// Nothing to put on the endpoint
-		return nil, nil
+		return nil
 	}
 
 	zEndpoint := &zipkinmodel.Endpoint{
@@ -182,7 +182,7 @@ func zipkinEndpointFromNode(node *commonpb.Node, serviceName string, endpointTyp
 		zEndpoint.IPv4 = ip
 	}
 
-	return zEndpoint, nil
+	return zEndpoint
 }
 
 func (ze *zipkinExporter) stop() error {
@@ -210,15 +210,13 @@ func (ze *zipkinExporter) ConsumeTraceData(ctx context.Context, td data.TraceDat
 		if err != nil {
 			return err
 		}
-		zs, err := ze.zipkinSpan(td.Node, sd)
-		if err == nil {
-			// ze.reporter can get closed in the midst of a Send
-			// so avoid a read/write during that mutation.
-			ze.mu.Lock()
-			ze.reporter.Send(zs)
-			ze.mu.Unlock()
-			goodSpans++
-		}
+		zs := ze.zipkinSpan(td.Node, sd)
+		// ze.reporter can get closed in the midst of a Send
+		// so avoid a read/write during that mutation.
+		ze.mu.Lock()
+		ze.reporter.Send(zs)
+		ze.mu.Unlock()
+		goodSpans++
 	}
 
 	// And finally record metrics on the number of exported spans.
@@ -320,15 +318,12 @@ const (
 
 const zipkinRemoteEndpointKey = "zipkin.remoteEndpoint.serviceName"
 
-func (ze *zipkinExporter) zipkinSpan(node *commonpb.Node, s *trace.SpanData) (zc zipkinmodel.SpanModel, err error) {
+func (ze *zipkinExporter) zipkinSpan(node *commonpb.Node, s *trace.SpanData) (zc zipkinmodel.SpanModel) {
 	localEndpointServiceName := ze.serviceNameOrDefault(node)
-	localEndpoint, err := zipkinEndpointFromNode(node, localEndpointServiceName, isLocalEndpoint)
-	if err != nil {
-		return zc, err
-	}
+	localEndpoint := zipkinEndpointFromNode(node, localEndpointServiceName, isLocalEndpoint)
 
 	remoteServiceName := lookupAttribute(node, zipkinRemoteEndpointKey)
-	remoteEndpoint, _ := zipkinEndpointFromNode(node, remoteServiceName, isRemoteEndpoint)
+	remoteEndpoint := zipkinEndpointFromNode(node, remoteServiceName, isRemoteEndpoint)
 
 	sc := s.SpanContext
 	z := zipkinmodel.SpanModel{
@@ -410,5 +405,5 @@ func (ze *zipkinExporter) zipkinSpan(node *commonpb.Node, s *trace.SpanData) (zc
 		}
 	}
 
-	return z, nil
+	return z
 }

--- a/exporter/zipkinexporter/zipkin_test.go
+++ b/exporter/zipkinexporter/zipkin_test.go
@@ -45,22 +45,19 @@ func TestZipkinEndpointFromNode(t *testing.T) {
 		endpointType zipkinDirection
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    *zipkinmodel.Endpoint
-		wantErr bool
+		name string
+		args args
+		want *zipkinmodel.Endpoint
 	}{
 		{
-			name:    "Nil Node",
-			args:    args{node: nil, serviceName: "", endpointType: isLocalEndpoint},
-			want:    nil,
-			wantErr: false,
+			name: "Nil Node",
+			args: args{node: nil, serviceName: "", endpointType: isLocalEndpoint},
+			want: nil,
 		},
 		{
-			name:    "Only svc name",
-			args:    args{node: &commonpb.Node{}, serviceName: "test", endpointType: isLocalEndpoint},
-			want:    &zipkinmodel.Endpoint{ServiceName: "test"},
-			wantErr: false,
+			name: "Only svc name",
+			args: args{node: &commonpb.Node{}, serviceName: "test", endpointType: isLocalEndpoint},
+			want: &zipkinmodel.Endpoint{ServiceName: "test"},
 		},
 		{
 			name: "Only ipv4",
@@ -71,8 +68,7 @@ func TestZipkinEndpointFromNode(t *testing.T) {
 				serviceName:  "",
 				endpointType: isLocalEndpoint,
 			},
-			want:    &zipkinmodel.Endpoint{IPv4: net.ParseIP("1.2.3.4")},
-			wantErr: false,
+			want: &zipkinmodel.Endpoint{IPv4: net.ParseIP("1.2.3.4")},
 		},
 		{
 			name: "Only ipv6 remote",
@@ -83,8 +79,7 @@ func TestZipkinEndpointFromNode(t *testing.T) {
 				serviceName:  "",
 				endpointType: isRemoteEndpoint,
 			},
-			want:    &zipkinmodel.Endpoint{IPv6: net.ParseIP("2001:0db8:85a3:0000:0000:8a2e:0370:7334")},
-			wantErr: false,
+			want: &zipkinmodel.Endpoint{IPv6: net.ParseIP("2001:0db8:85a3:0000:0000:8a2e:0370:7334")},
 		},
 		{
 			name: "Only port",
@@ -95,8 +90,7 @@ func TestZipkinEndpointFromNode(t *testing.T) {
 				serviceName:  "",
 				endpointType: isLocalEndpoint,
 			},
-			want:    &zipkinmodel.Endpoint{Port: 42},
-			wantErr: false,
+			want: &zipkinmodel.Endpoint{Port: 42},
 		},
 		{
 			name: "Service name, ipv4, and port",
@@ -107,18 +101,13 @@ func TestZipkinEndpointFromNode(t *testing.T) {
 				serviceName:  "test-svc",
 				endpointType: isLocalEndpoint,
 			},
-			want:    &zipkinmodel.Endpoint{ServiceName: "test-svc", IPv4: net.ParseIP("4.3.2.1"), Port: 2},
-			wantErr: false,
+			want: &zipkinmodel.Endpoint{ServiceName: "test-svc", IPv4: net.ParseIP("4.3.2.1"), Port: 2},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := zipkinEndpointFromNode(tt.args.node, tt.args.serviceName, tt.args.endpointType)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("zipkinEndpointFromNode() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			got := zipkinEndpointFromNode(tt.args.node, tt.args.serviceName, tt.args.endpointType)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("zipkinEndpointFromNode() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
These 2 functions had error on their return but never returned error. This made confuse on caller sites since it gave the impression that spans could be dropped without proper observability.