### PR TITLE
Add workaround for data race in TestApplication_StartUnified

### DIFF
--- a/cmd/occollector/app/collector/collector_test.go
+++ b/cmd/occollector/app/collector/collector_test.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/open-telemetry/opentelemetry-service/internal/testutils"
 	"github.com/open-telemetry/opentelemetry-service/internal/zpagesserver"
@@ -94,6 +95,19 @@ func TestApplication_StartUnified(t *testing.T) {
 	if !isAppAvailable(t, "http://"+addresses[0]) {
 		t.Fatalf("App didn't reach ready state")
 	}
+
+	// We have to wait here work around a data race bug in Jaeger
+	// (https://github.com/jaegertracing/jaeger/pull/1625) caused
+	// by stopping immediately after starting.
+	//
+	// Without this Sleep we were observing this bug on our side:
+	// https://github.com/open-telemetry/opentelemetry-service/issues/43
+	// The Sleep ensures that Jaeger Start() is fully completed before
+	// we call Jaeger Stop().
+	// TODO: Jaeger bug is already fixed, remove this once we update Jaeger
+	// to latest version.
+	time.Sleep(1 * time.Second)
+
 	close(App.stopTestChan)
 	<-appDone
 }


### PR DESCRIPTION
Added a Sleep to work around a data race bug in Jaeger
(https://github.com/jaegertracing/jaeger/pull/1625) caused
by stopping immediately after starting.

Without this Sleep we were observing this bug on our side:
https://github.com/open-telemetry/opentelemetry-service/issues/43
The Sleep ensures that Jaeger Start() is fully completed before
we call Jaeger Stop().

TODO: Jaeger bug is already fixed, remove this once we update Jaeger
to latest version.

Testing done: make test