### PR TITLE
Skip TestCreateReceiver for VM Metrics receiver if not on linux

### DIFF
--- a/receiver/vmmetricsreceiver/factory.go
+++ b/receiver/vmmetricsreceiver/factory.go
@@ -16,6 +16,8 @@ package vmmetricsreceiver
 
 import (
 	"context"
+	"errors"
+	"runtime"
 
 	"go.uber.org/zap"
 
@@ -75,6 +77,9 @@ func (f *Factory) CreateMetricsReceiver(
 	consumer consumer.MetricsConsumer,
 ) (receiver.MetricsReceiver, error) {
 
+	if runtime.GOOS != "linux" {
+		return nil, errors.New("vmmetrics receiver is only supported on linux")
+	}
 	cfg := config.(*ConfigV2)
 
 	vmc, err := NewVMMetricsCollector(cfg.ScrapeInterval, cfg.MountPoint, cfg.ProcessMountPoint, cfg.MetricPrefix, consumer)

--- a/receiver/vmmetricsreceiver/factory_test.go
+++ b/receiver/vmmetricsreceiver/factory_test.go
@@ -16,6 +16,7 @@ package vmmetricsreceiver
 
 import (
 	"context"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,6 +33,9 @@ func TestCreateDefaultConfig(t *testing.T) {
 }
 
 func TestCreateReceiver(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("vmmetricsreceiver currently only supported on linux")
+	}
 	factory := receiver.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 

--- a/receiver/vmmetricsreceiver/factory_test.go
+++ b/receiver/vmmetricsreceiver/factory_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-service/models"
@@ -33,17 +34,23 @@ func TestCreateDefaultConfig(t *testing.T) {
 }
 
 func TestCreateReceiver(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("vmmetricsreceiver currently only supported on linux")
-	}
 	factory := receiver.GetReceiverFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 
 	tReceiver, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
+
 	assert.Equal(t, err, models.ErrDataTypeIsNotSupported)
 	assert.Nil(t, tReceiver)
 
 	mReceiver, err := factory.CreateMetricsReceiver(zap.NewNop(), cfg, nil)
+
+	// Currently vmmetrics receiver is only supported on linux.
+	if runtime.GOOS != "linux" {
+		require.Nil(t, tReceiver)
+		require.NotNil(t, err)
+		return
+	}
+
 	assert.Nil(t, err)
 	assert.NotNil(t, mReceiver)
 }


### PR DESCRIPTION
Skip the test if not on linux since currently VM Metrics receiver only supports Linux.

This can be done in other ways (e.g.: rename file, build directive, etc) but I think it is better to keep building it but only skip the failing test on other platforms.

Fixes #104