### PR TITLE
Move data to consumerdata

### DIFF
--- a/cmd/occollector/app/builder/pipelines_builder_test.go
+++ b/cmd/occollector/app/builder/pipelines_builder_test.go
@@ -26,7 +26,7 @@ import (
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 
 	"github.com/open-telemetry/opentelemetry-service/configv2"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/models"
 	"github.com/open-telemetry/opentelemetry-service/processor/addattributesprocessor"
 )
@@ -102,7 +102,7 @@ func testPipeline(t *testing.T, pipelineName string, exporterNames []string) {
 
 	// Send one trace.
 	name := tracepb.TruncatableString{Value: "testspanname"}
-	traceData := data.TraceData{
+	traceData := consumerdata.TraceData{
 		SourceFormat: "test-source-format",
 		Spans: []*tracepb.Span{
 			{Name: &name},

--- a/cmd/occollector/app/builder/receivers_builder_test.go
+++ b/cmd/occollector/app/builder/receivers_builder_test.go
@@ -27,7 +27,7 @@ import (
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 
 	"github.com/open-telemetry/opentelemetry-service/configv2"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/models"
 	"github.com/open-telemetry/opentelemetry-service/receiver/receivertest"
 )
@@ -139,7 +139,7 @@ func testReceivers(
 
 	// Send one trace.
 	name := tracepb.TruncatableString{Value: "testspanname"}
-	traceData := data.TraceData{
+	traceData := consumerdata.TraceData{
 		SourceFormat: "test-source-format",
 		Spans: []*tracepb.Span{
 			{Name: &name},
@@ -150,7 +150,7 @@ func testReceivers(
 		traceProducer.TraceConsumer.ConsumeTraceData(context.Background(), traceData)
 	}
 
-	metricsData := data.MetricsData{
+	metricsData := consumerdata.MetricsData{
 		Metrics: []*metricspb.Metric{
 			{MetricDescriptor: &metricspb.MetricDescriptor{Name: "testmetric"}},
 		},

--- a/cmd/occollector/app/sender/jaeger_proto_grpc_sender.go
+++ b/cmd/occollector/app/sender/jaeger_proto_grpc_sender.go
@@ -23,7 +23,7 @@ import (
 	jaegerproto "github.com/jaegertracing/jaeger/proto-gen/api_v2"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/errors/errorkind"
 	jaegertranslator "github.com/open-telemetry/opentelemetry-service/translator/trace/jaeger"
 )
@@ -51,8 +51,8 @@ func NewJaegerProtoGRPCSender(collectorEndpoint string, zlogger *zap.Logger) *Ja
 	return s
 }
 
-// ConsumeTraceData receives data.TraceData for processing by the JaegerProtoGRPCSender.
-func (s *JaegerProtoGRPCSender) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+// ConsumeTraceData receives consumerdata.TraceData for processing by the JaegerProtoGRPCSender.
+func (s *JaegerProtoGRPCSender) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	protoBatch, err := jaegertranslator.OCProtoToJaegerProto(td)
 	if err != nil {
 		s.logger.Warn("Error translating OC proto batch to Jaeger proto", zap.Error(err))

--- a/cmd/occollector/app/sender/jaeger_thrift_http_sender.go
+++ b/cmd/occollector/app/sender/jaeger_thrift_http_sender.go
@@ -27,7 +27,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/errors/errorkind"
 	jaegertranslator "github.com/open-telemetry/opentelemetry-service/translator/trace/jaeger"
 )
@@ -85,7 +85,7 @@ func NewJaegerThriftHTTPSender(
 }
 
 // ConsumeTraceData sends the received data to the configured Jaeger Thrift end-point.
-func (s *JaegerThriftHTTPSender) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (s *JaegerThriftHTTPSender) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	// TODO: (@pjanotti) In case of failure the translation to Jaeger Thrift is going to be remade, cache it somehow.
 	tBatch, err := jaegertranslator.OCProtoToJaegerThrift(td)
 	if err != nil {

--- a/cmd/occollector/app/sender/jaeger_thrift_tchannel_sender.go
+++ b/cmd/occollector/app/sender/jaeger_thrift_tchannel_sender.go
@@ -21,7 +21,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/errors/errorkind"
 	jaegertranslator "github.com/open-telemetry/opentelemetry-service/translator/trace/jaeger"
 )
@@ -47,7 +47,7 @@ func NewJaegerThriftTChannelSender(
 }
 
 // ConsumeTraceData sends the received data to the configured Jaeger Thrift end-point.
-func (s *JaegerThriftTChannelSender) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (s *JaegerThriftTChannelSender) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	// TODO: (@pjanotti) In case of failure the translation to Jaeger Thrift is going to be remade, cache it somehow.
 	tBatch, err := jaegertranslator.OCProtoToJaegerThrift(td)
 	if err != nil {

--- a/configv2/example_factories.go
+++ b/configv2/example_factories.go
@@ -20,7 +20,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter"
 	"github.com/open-telemetry/opentelemetry-service/factories"
 	"github.com/open-telemetry/opentelemetry-service/models"
@@ -265,18 +265,18 @@ func (f *ExampleExporterFactory) CreateMetricsExporter(logger *zap.Logger, cfg m
 
 // ExampleExporterConsumer stores consumed traces and metrics for testing purposes.
 type ExampleExporterConsumer struct {
-	Traces  []data.TraceData
-	Metrics []data.MetricsData
+	Traces  []consumerdata.TraceData
+	Metrics []consumerdata.MetricsData
 }
 
-// ConsumeTraceData receives data.TraceData for processing by the TraceConsumer.
-func (exp *ExampleExporterConsumer) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+// ConsumeTraceData receives consumerdata.TraceData for processing by the TraceConsumer.
+func (exp *ExampleExporterConsumer) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	exp.Traces = append(exp.Traces, td)
 	return nil
 }
 
-// ConsumeMetricsData receives data.MetricsData for processing by the MetricsConsumer.
-func (exp *ExampleExporterConsumer) ConsumeMetricsData(ctx context.Context, md data.MetricsData) error {
+// ConsumeMetricsData receives consumerdata.MetricsData for processing by the MetricsConsumer.
+func (exp *ExampleExporterConsumer) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
 	exp.Metrics = append(exp.Metrics, md)
 	return nil
 }

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -17,23 +17,23 @@ package consumer
 import (
 	"context"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 )
 
-// MetricsConsumer is an interface that receives data.MetricsData, process it as needed, and
+// MetricsConsumer is an interface that receives consumerdata.MetricsData, process it as needed, and
 // sends it to the next processing node if any or to the destination.
 //
-// ConsumeMetricsData receives data.MetricsData for processing by the MetricsConsumer.
+// ConsumeMetricsData receives consumerdata.MetricsData for processing by the MetricsConsumer.
 type MetricsConsumer interface {
-	ConsumeMetricsData(ctx context.Context, md data.MetricsData) error
+	ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error
 }
 
-// TraceConsumer is an interface that receives data.TraceData, process it as needed, and
+// TraceConsumer is an interface that receives consumerdata.TraceData, process it as needed, and
 // sends it to the next processing node if any or to the destination.
 //
-// ConsumeTraceData receives data.TraceData for processing by the TraceConsumer.
+// ConsumeTraceData receives consumerdata.TraceData for processing by the TraceConsumer.
 type TraceConsumer interface {
-	ConsumeTraceData(ctx context.Context, td data.TraceData) error
+	ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error
 }
 
 // DataConsumer is a union type that can accept traces and/or metrics.

--- a/consumer/consumerdata/consumerdata.go
+++ b/consumer/consumerdata/consumerdata.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package data
+package consumerdata
 
 import (
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"

--- a/consumer/consumerdata/empty_test.go
+++ b/consumer/consumerdata/empty_test.go
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package data
+package consumerdata

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -20,13 +20,13 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/observability"
 	"go.opencensus.io/trace"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter"
 )
 
 // PushMetricsData is a helper function that is similar to ConsumeMetricsData but also returns
 // the number of dropped metrics.
-type PushMetricsData func(ctx context.Context, td data.MetricsData) (droppedMetrics int, err error)
+type PushMetricsData func(ctx context.Context, td consumerdata.MetricsData) (droppedMetrics int, err error)
 
 type metricsExporter struct {
 	exporterFormat  string
@@ -39,7 +39,7 @@ func (me *metricsExporter) MetricsExportFormat() string {
 	return me.exporterFormat
 }
 
-func (me *metricsExporter) ConsumeMetricsData(ctx context.Context, md data.MetricsData) error {
+func (me *metricsExporter) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
 	exporterCtx := observability.ContextWithExporterName(ctx, me.exporterFormat)
 	_, err := me.pushMetricsData(exporterCtx, md)
 	return err
@@ -71,7 +71,7 @@ func NewMetricsExporter(exporterFormat string, pushMetricsData PushMetricsData, 
 }
 
 func pushMetricsDataWithSpan(next PushMetricsData, spanName string) PushMetricsData {
-	return func(ctx context.Context, md data.MetricsData) (int, error) {
+	return func(ctx context.Context, md consumerdata.MetricsData) (int, error) {
 		ctx, span := trace.StartSpan(ctx, spanName)
 		defer span.End()
 		// Call next stage.

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -21,7 +21,7 @@ import (
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	"go.opencensus.io/trace"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter"
 )
 
@@ -37,7 +37,7 @@ func TestMetricsExporter_NilPushMetricsData(t *testing.T) {
 	}
 }
 func TestMetricsExporter_Default(t *testing.T) {
-	td := data.MetricsData{}
+	td := consumerdata.MetricsData{}
 	te, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, nil))
 	if err != nil {
 		t.Fatalf("NewMetricsExporter returns: Want nil Got %v", err)
@@ -51,7 +51,7 @@ func TestMetricsExporter_Default(t *testing.T) {
 }
 
 func TestMetricsExporter_Default_ReturnError(t *testing.T) {
-	td := data.MetricsData{}
+	td := consumerdata.MetricsData{}
 	want := errors.New("my_error")
 	te, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, want))
 	if err != nil {
@@ -88,13 +88,13 @@ func TestMetricsExporter_WithSpan_ReturnError(t *testing.T) {
 }
 
 func newPushMetricsData(droppedSpans int, retError error) PushMetricsData {
-	return func(ctx context.Context, td data.MetricsData) (int, error) {
+	return func(ctx context.Context, td consumerdata.MetricsData) (int, error) {
 		return droppedSpans, retError
 	}
 }
 
 func generateMetricsTraffic(t *testing.T, te exporter.MetricsExporter, numRequests int, wantError error) {
-	td := data.MetricsData{Metrics: make([]*metricspb.Metric, 1, 1)}
+	td := consumerdata.MetricsData{Metrics: make([]*metricspb.Metric, 1, 1)}
 	ctx, span := trace.StartSpan(context.Background(), fakeParentSpanName, trace.WithSampler(trace.AlwaysSample()))
 	defer span.End()
 	for i := 0; i < numRequests; i++ {

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -22,7 +22,7 @@ import (
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"go.opencensus.io/trace"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter"
 	"github.com/open-telemetry/opentelemetry-service/observability"
 	"github.com/open-telemetry/opentelemetry-service/observability/observabilitytest"
@@ -47,7 +47,7 @@ func TestTraceExporter_NilPushTraceData(t *testing.T) {
 	}
 }
 func TestTraceExporter_Default(t *testing.T) {
-	td := data.TraceData{}
+	td := consumerdata.TraceData{}
 	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, nil))
 	if err != nil {
 		t.Fatalf("NewTraceExporter returns: Want nil Got %v", err)
@@ -61,7 +61,7 @@ func TestTraceExporter_Default(t *testing.T) {
 }
 
 func TestTraceExporter_Default_ReturnError(t *testing.T) {
-	td := data.TraceData{}
+	td := consumerdata.TraceData{}
 	want := errors.New("my_error")
 	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, want))
 	if err != nil {
@@ -123,7 +123,7 @@ func TestTraceExporter_WithSpan_ReturnError(t *testing.T) {
 }
 
 func newPushTraceData(droppedSpans int, retError error) PushTraceData {
-	return func(ctx context.Context, td data.TraceData) (int, error) {
+	return func(ctx context.Context, td consumerdata.TraceData) (int, error) {
 		return droppedSpans, retError
 	}
 }
@@ -133,7 +133,7 @@ func checkRecordedMetricsForTraceExporter(t *testing.T, te exporter.TraceExporte
 	defer doneFn()
 
 	spans := make([]*tracepb.Span, 2, 2)
-	td := data.TraceData{Spans: spans}
+	td := consumerdata.TraceData{Spans: spans}
 	ctx := observability.ContextWithReceiverName(context.Background(), fakeReceiverName)
 	const numBatches = 7
 	for i := 0; i < numBatches; i++ {
@@ -151,7 +151,7 @@ func checkRecordedMetricsForTraceExporter(t *testing.T, te exporter.TraceExporte
 }
 
 func generateTraceTraffic(t *testing.T, te exporter.TraceExporter, numRequests int, wantError error) {
-	td := data.TraceData{Spans: make([]*tracepb.Span, 1, 1)}
+	td := consumerdata.TraceData{Spans: make([]*tracepb.Span, 1, 1)}
 	ctx, span := trace.StartSpan(context.Background(), fakeParentSpanName, trace.WithSampler(trace.AlwaysSample()))
 	defer span.End()
 	for i := 0; i < numRequests; i++ {

--- a/exporter/exportertest/nop_exporter.go
+++ b/exporter/exportertest/nop_exporter.go
@@ -17,7 +17,7 @@ package exportertest
 import (
 	"context"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter"
 )
 
@@ -29,11 +29,11 @@ type nopExporter struct{ retError error }
 var _ exporter.TraceExporter = (*nopExporter)(nil)
 var _ exporter.MetricsExporter = (*nopExporter)(nil)
 
-func (ne *nopExporter) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (ne *nopExporter) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	return ne.retError
 }
 
-func (ne *nopExporter) ConsumeMetricsData(ctx context.Context, md data.MetricsData) error {
+func (ne *nopExporter) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
 	return ne.retError
 }
 

--- a/exporter/exportertest/nop_exporter_test.go
+++ b/exporter/exportertest/nop_exporter_test.go
@@ -20,12 +20,12 @@ import (
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 )
 
 func TestNopTraceExporter_NoErrors(t *testing.T) {
 	nte := NewNopTraceExporter()
-	td := data.TraceData{
+	td := consumerdata.TraceData{
 		Spans: make([]*tracepb.Span, 7),
 	}
 	if err := nte.ConsumeTraceData(context.Background(), td); err != nil {
@@ -39,7 +39,7 @@ func TestNopTraceExporter_NoErrors(t *testing.T) {
 func TestNopTraceExporter_WithErrors(t *testing.T) {
 	want := errors.New("MyError")
 	nte := NewNopTraceExporter(WithReturnError(want))
-	td := data.TraceData{
+	td := consumerdata.TraceData{
 		Spans: make([]*tracepb.Span, 7),
 	}
 	if got := nte.ConsumeTraceData(context.Background(), td); got != want {
@@ -52,7 +52,7 @@ func TestNopTraceExporter_WithErrors(t *testing.T) {
 
 func TestNopMetricsExporter_NoErrors(t *testing.T) {
 	nme := NewNopMetricsExporter()
-	md := data.MetricsData{
+	md := consumerdata.MetricsData{
 		Metrics: make([]*metricspb.Metric, 7),
 	}
 	if err := nme.ConsumeMetricsData(context.Background(), md); err != nil {
@@ -66,7 +66,7 @@ func TestNopMetricsExporter_NoErrors(t *testing.T) {
 func TestNopMetricsExporter_WithErrors(t *testing.T) {
 	want := errors.New("MyError")
 	nme := NewNopMetricsExporter(WithReturnError(want))
-	md := data.MetricsData{
+	md := consumerdata.MetricsData{
 		Metrics: make([]*metricspb.Metric, 7),
 	}
 	if got := nme.ConsumeMetricsData(context.Background(), md); got != want {

--- a/exporter/exportertest/sink_exporter.go
+++ b/exporter/exportertest/sink_exporter.go
@@ -18,20 +18,20 @@ import (
 	"context"
 	"sync"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter"
 )
 
 // SinkTraceExporter acts as a trace receiver for use in tests.
 type SinkTraceExporter struct {
 	mu     sync.Mutex
-	traces []data.TraceData
+	traces []consumerdata.TraceData
 }
 
 var _ exporter.TraceExporter = (*SinkTraceExporter)(nil)
 
 // ConsumeTraceData stores traces for tests.
-func (ste *SinkTraceExporter) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (ste *SinkTraceExporter) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	ste.mu.Lock()
 	defer ste.mu.Unlock()
 
@@ -51,7 +51,7 @@ func (ste *SinkTraceExporter) TraceExportFormat() string {
 }
 
 // AllTraces returns the traces sent to the test sink.
-func (ste *SinkTraceExporter) AllTraces() []data.TraceData {
+func (ste *SinkTraceExporter) AllTraces() []consumerdata.TraceData {
 	ste.mu.Lock()
 	defer ste.mu.Unlock()
 
@@ -61,13 +61,13 @@ func (ste *SinkTraceExporter) AllTraces() []data.TraceData {
 // SinkMetricsExporter acts as a metrics receiver for use in tests.
 type SinkMetricsExporter struct {
 	mu      sync.Mutex
-	metrics []data.MetricsData
+	metrics []consumerdata.MetricsData
 }
 
 var _ exporter.MetricsExporter = (*SinkMetricsExporter)(nil)
 
 // ConsumeMetricsData stores traces for tests.
-func (sme *SinkMetricsExporter) ConsumeMetricsData(ctx context.Context, md data.MetricsData) error {
+func (sme *SinkMetricsExporter) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
 	sme.mu.Lock()
 	defer sme.mu.Unlock()
 
@@ -82,7 +82,7 @@ func (sme *SinkMetricsExporter) MetricsExportFormat() string {
 }
 
 // AllMetrics returns the metrics sent to the test sink.
-func (sme *SinkMetricsExporter) AllMetrics() []data.MetricsData {
+func (sme *SinkMetricsExporter) AllMetrics() []consumerdata.MetricsData {
 	sme.mu.Lock()
 	defer sme.mu.Unlock()
 

--- a/exporter/exportertest/sink_exporter_test.go
+++ b/exporter/exportertest/sink_exporter_test.go
@@ -20,15 +20,15 @@ import (
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 )
 
 func TestSinkTraceExporter(t *testing.T) {
 	sink := new(SinkTraceExporter)
-	td := data.TraceData{
+	td := consumerdata.TraceData{
 		Spans: make([]*tracepb.Span, 7),
 	}
-	want := make([]data.TraceData, 0, 7)
+	want := make([]consumerdata.TraceData, 0, 7)
 	for i := 0; i < 7; i++ {
 		if err := sink.ConsumeTraceData(context.Background(), td); err != nil {
 			t.Fatalf("Wanted nil got error")
@@ -46,10 +46,10 @@ func TestSinkTraceExporter(t *testing.T) {
 
 func TestSinkMetricsExporter(t *testing.T) {
 	sink := new(SinkMetricsExporter)
-	md := data.MetricsData{
+	md := consumerdata.MetricsData{
 		Metrics: make([]*metricspb.Metric, 7),
 	}
-	want := make([]data.MetricsData, 0, 7)
+	want := make([]consumerdata.MetricsData, 0, 7)
 	for i := 0; i < 7; i++ {
 		if err := sink.ConsumeMetricsData(context.Background(), md); err != nil {
 			t.Fatalf("Wanted nil got error")

--- a/exporter/exporterwrapper/exporterwrapper.go
+++ b/exporter/exporterwrapper/exporterwrapper.go
@@ -25,7 +25,7 @@ import (
 	"go.opencensus.io/trace"
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exporterhelper"
 	"github.com/open-telemetry/opentelemetry-service/internal"
@@ -43,7 +43,7 @@ import (
 func NewExporterWrapper(exporterName string, spanName string, ocExporter trace.Exporter) (exporter.TraceExporter, error) {
 	return exporterhelper.NewTraceExporter(
 		exporterName,
-		func(ctx context.Context, td data.TraceData) (int, error) {
+		func(ctx context.Context, td consumerdata.TraceData) (int, error) {
 			return PushOcProtoSpansToOCTraceExporter(ocExporter, td)
 		},
 		exporterhelper.WithSpanName(spanName),
@@ -55,7 +55,7 @@ func NewExporterWrapper(exporterName string, spanName string, ocExporter trace.E
 
 // PushOcProtoSpansToOCTraceExporter pushes TraceData to the given trace.Exporter by converting the
 // protos to trace.SpanData.
-func PushOcProtoSpansToOCTraceExporter(ocExporter trace.Exporter, td data.TraceData) (int, error) {
+func PushOcProtoSpansToOCTraceExporter(ocExporter trace.Exporter, td consumerdata.TraceData) (int, error) {
 	var errs []error
 	var goodSpans []*tracepb.Span
 	for _, span := range td.Spans {

--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -17,7 +17,7 @@ package loggingexporter
 import (
 	"context"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exporterhelper"
 	"go.uber.org/zap"
@@ -33,7 +33,7 @@ const (
 func NewTraceExporter(logger *zap.Logger) (exporter.TraceExporter, error) {
 	return exporterhelper.NewTraceExporter(
 		traceExportFormat,
-		func(ctx context.Context, td data.TraceData) (int, error) {
+		func(ctx context.Context, td consumerdata.TraceData) (int, error) {
 			logger.Debug("loggingTraceExporter", zap.Int("#spans", len(td.Spans)))
 			// TODO: Add ability to record the received data
 			return 0, nil
@@ -47,7 +47,7 @@ func NewTraceExporter(logger *zap.Logger) (exporter.TraceExporter, error) {
 func NewMetricsExporter(logger *zap.Logger) (exporter.MetricsExporter, error) {
 	return exporterhelper.NewMetricsExporter(
 		metricsExportFormat,
-		func(ctx context.Context, md data.MetricsData) (int, error) {
+		func(ctx context.Context, md consumerdata.MetricsData) (int, error) {
 			logger.Debug("loggingMetricsExporter", zap.Int("#metrics", len(md.Metrics)))
 			// TODO: Add ability to record the received data
 			return 0, nil

--- a/exporter/loggingexporter/logging_exporter_test.go
+++ b/exporter/loggingexporter/logging_exporter_test.go
@@ -19,7 +19,7 @@ import (
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"go.uber.org/zap"
 )
 
@@ -28,7 +28,7 @@ func TestLoggingTraceExporterNoErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Wanted nil got %v", err)
 	}
-	td := data.TraceData{
+	td := consumerdata.TraceData{
 		Spans: make([]*tracepb.Span, 7),
 	}
 	if err := lte.ConsumeTraceData(context.Background(), td); err != nil {
@@ -44,7 +44,7 @@ func TestLoggingMetricsExporterNoErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Wanted nil got %v", err)
 	}
-	md := data.MetricsData{
+	md := consumerdata.MetricsData{
 		Metrics: make([]*metricspb.Metric, 7),
 	}
 	if err := lme.ConsumeMetricsData(context.Background(), md); err != nil {

--- a/exporter/opencensusexporter/opencensus.go
+++ b/exporter/opencensusexporter/opencensus.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exporterhelper"
 	"github.com/open-telemetry/opentelemetry-service/internal"
 	"github.com/open-telemetry/opentelemetry-service/internal/compression"
@@ -218,7 +218,7 @@ func (oce *ocagentExporter) stop() error {
 	return internal.CombineErrors(errors)
 }
 
-func (oce *ocagentExporter) PushTraceData(ctx context.Context, td data.TraceData) (int, error) {
+func (oce *ocagentExporter) PushTraceData(ctx context.Context, td consumerdata.TraceData) (int, error) {
 	// Get first available exporter.
 	exporter, ok := <-oce.exporters
 	if !ok {

--- a/exporter/opencensusexporter/opencensusexporter_test.go
+++ b/exporter/opencensusexporter/opencensusexporter_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/viper"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 )
 
 func TestOpenCensusTraceExportersFromViper(t *testing.T) {
@@ -113,7 +113,7 @@ func TestOpenCensusTraceExporters_StopError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("doneFn[0]() got = %v, want = nil", err)
 	}
-	err = tps[0].ConsumeTraceData(context.Background(), data.TraceData{})
+	err = tps[0].ConsumeTraceData(context.Background(), consumerdata.TraceData{})
 	if errorCode(err) != errAlreadyStopped {
 		t.Fatalf("Expected to get errAlreadyStopped but got %v", err)
 	}

--- a/exporter/prometheusexporter/prometheus.go
+++ b/exporter/prometheusexporter/prometheus.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/spf13/viper"
 
 	// TODO: once this repository has been transferred to the
@@ -103,7 +103,7 @@ type prometheusExporter struct {
 
 var _ consumer.MetricsConsumer = (*prometheusExporter)(nil)
 
-func (pe *prometheusExporter) ConsumeMetricsData(ctx context.Context, md data.MetricsData) error {
+func (pe *prometheusExporter) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
 	for _, metric := range md.Metrics {
 		_ = pe.exporter.ExportMetric(ctx, md.Node, md.Resource, metric)
 	}

--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -27,7 +27,7 @@ import (
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter"
 	"github.com/open-telemetry/opentelemetry-service/internal/config/viperutils"
 )
@@ -147,7 +147,7 @@ func TestPrometheusExporter_endToEnd(t *testing.T) {
 			},
 		},
 	}
-	consumer.ConsumeMetricsData(context.Background(), data.MetricsData{Metrics: []*metricspb.Metric{metric1}})
+	consumer.ConsumeMetricsData(context.Background(), consumerdata.MetricsData{Metrics: []*metricspb.Metric{metric1}})
 
 	res, err := http.Get("http://localhost:7777/metrics")
 	if err != nil {

--- a/exporter/zipkinexporter/zipkin.go
+++ b/exporter/zipkinexporter/zipkin.go
@@ -30,7 +30,7 @@ import (
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/errors/errorkind"
 	"github.com/open-telemetry/opentelemetry-service/observability"
 	"github.com/open-telemetry/opentelemetry-service/translator/trace"
@@ -192,7 +192,7 @@ func (ze *zipkinExporter) stop() error {
 	return ze.reporter.Close()
 }
 
-func (ze *zipkinExporter) ConsumeTraceData(ctx context.Context, td data.TraceData) (zerr error) {
+func (ze *zipkinExporter) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) (zerr error) {
 	ctx, span := trace.StartSpan(ctx,
 		"opencensus.service.exporter.zipkin.ExportTrace",
 		trace.WithSampler(trace.NeverSample()))

--- a/internal/collector/processor/nodebatcher/node_batcher.go
+++ b/internal/collector/processor/nodebatcher/node_batcher.go
@@ -30,7 +30,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/internal/collector/processor"
 	"github.com/open-telemetry/opentelemetry-service/observability"
 )
@@ -104,7 +104,7 @@ func NewBatcher(name string, logger *zap.Logger, sender consumer.TraceConsumer, 
 
 // ConsumeTraceData implements batcher as a SpanProcessor and takes the provided spans and adds them to
 // batches
-func (b *batcher) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (b *batcher) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	bucketID := b.genBucketID(td.Node, td.Resource, td.SourceFormat)
 	bucket := b.getOrAddBucket(bucketID, td.Node, td.Resource, td.SourceFormat)
 	bucket.add(td.Spans)
@@ -220,7 +220,7 @@ func (nb *nodeBatch) sendItems(
 	for _, items := range itemsToProcess {
 		tdItems = append(tdItems, items...)
 	}
-	td := data.TraceData{
+	td := consumerdata.TraceData{
 		Node:         nb.node,
 		Resource:     nb.resource,
 		Spans:        tdItems,

--- a/internal/collector/processor/nodebatcher/node_batcher_test.go
+++ b/internal/collector/processor/nodebatcher/node_batcher_test.go
@@ -23,7 +23,7 @@ import (
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"go.uber.org/zap"
 )
 
@@ -146,7 +146,7 @@ func TestConcurrentNodeAdds(t *testing.T) {
 		for spanIndex := 0; spanIndex < spansPerRequest; spanIndex++ {
 			spans = append(spans, &tracepb.Span{Name: getTestSpanName(requestNum, spanIndex)})
 		}
-		td := data.TraceData{
+		td := consumerdata.TraceData{
 			Node: &commonpb.Node{
 				ServiceInfo: &commonpb.ServiceInfo{Name: fmt.Sprintf("svc-%d", requestNum)},
 			},
@@ -194,7 +194,7 @@ func TestBucketRemove(t *testing.T) {
 	for spanIndex := 0; spanIndex < spansPerRequest; spanIndex++ {
 		spans = append(spans, &tracepb.Span{Name: getTestSpanName(0, spanIndex)})
 	}
-	request := data.TraceData{
+	request := consumerdata.TraceData{
 		Node: &commonpb.Node{
 			ServiceInfo: &commonpb.ServiceInfo{Name: "svc"},
 		},
@@ -245,7 +245,7 @@ func TestBucketTickerStop(t *testing.T) {
 	for spanIndex := 0; spanIndex < spansPerRequest; spanIndex++ {
 		spans = append(spans, &tracepb.Span{Name: getTestSpanName(0, spanIndex)})
 	}
-	request := data.TraceData{
+	request := consumerdata.TraceData{
 		Node: &commonpb.Node{
 			ServiceInfo: &commonpb.ServiceInfo{Name: "svc"},
 		},
@@ -275,7 +275,7 @@ func TestConcurrentBatchAdds(t *testing.T) {
 		for spanIndex := 0; spanIndex < spansPerRequest; spanIndex++ {
 			spans = append(spans, &tracepb.Span{Name: getTestSpanName(requestNum, spanIndex)})
 		}
-		request := data.TraceData{
+		request := consumerdata.TraceData{
 			Node: &commonpb.Node{
 				ServiceInfo: &commonpb.ServiceInfo{Name: "svc"},
 			},
@@ -306,12 +306,12 @@ func BenchmarkConcurrentBatchAdds(b *testing.B) {
 	sender1 := newNopSender()
 	batcher := NewBatcher("test", zap.NewNop(), sender1).(*batcher)
 	spansPerRequest := 1000
-	var requests []data.TraceData
+	var requests []consumerdata.TraceData
 	spans := make([]*tracepb.Span, 0, spansPerRequest)
 	for spanIndex := 0; spanIndex < spansPerRequest; spanIndex++ {
 		spans = append(spans, &tracepb.Span{Name: getTestSpanName(0, spanIndex)})
 	}
-	request := data.TraceData{
+	request := consumerdata.TraceData{
 		Node: &commonpb.Node{
 			ServiceInfo: &commonpb.ServiceInfo{Name: "svc"},
 		},
@@ -341,12 +341,12 @@ func newNopSender() *nopSender {
 	return &nopSender{}
 }
 
-func (ts *nopSender) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (ts *nopSender) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	return nil
 }
 
 type testSender struct {
-	reqChan             chan data.TraceData
+	reqChan             chan consumerdata.TraceData
 	batchesReceived     int
 	spansReceived       int
 	spansReceivedByName map[string]*tracepb.Span
@@ -354,12 +354,12 @@ type testSender struct {
 
 func newTestSender() *testSender {
 	return &testSender{
-		reqChan:             make(chan data.TraceData, 100),
+		reqChan:             make(chan consumerdata.TraceData, 100),
 		spansReceivedByName: make(map[string]*tracepb.Span),
 	}
 }
 
-func (ts *testSender) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (ts *testSender) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	ts.reqChan <- td
 	return nil
 }

--- a/internal/collector/processor/queued/queued_processor.go
+++ b/internal/collector/processor/queued/queued_processor.go
@@ -26,7 +26,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/errors/errorkind"
 	"github.com/open-telemetry/opentelemetry-service/internal/collector/processor"
 	"github.com/open-telemetry/opentelemetry-service/internal/collector/processor/nodebatcher"
@@ -49,7 +49,7 @@ var _ consumer.TraceConsumer = (*queuedSpanProcessor)(nil)
 
 type queueItem struct {
 	queuedTime time.Time
-	td         data.TraceData
+	td         consumerdata.TraceData
 	ctx        context.Context
 }
 
@@ -113,7 +113,7 @@ func (sp *queuedSpanProcessor) Stop() {
 }
 
 // ConsumeTraceData implements the SpanProcessor interface
-func (sp *queuedSpanProcessor) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (sp *queuedSpanProcessor) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	item := &queueItem{
 		queuedTime: time.Now(),
 		td:         td,

--- a/internal/collector/processor/tailsampling/processor.go
+++ b/internal/collector/processor/tailsampling/processor.go
@@ -27,7 +27,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/internal/collector/processor/idbatcher"
 	"github.com/open-telemetry/opentelemetry-service/internal/collector/sampling"
 	"github.com/open-telemetry/opentelemetry-service/observability"
@@ -183,7 +183,7 @@ func (tsp *tailSamplingSpanProcessor) samplingPolicyOnTick() {
 }
 
 // ConsumeTraceData is required by the SpanProcessor interface.
-func (tsp *tailSamplingSpanProcessor) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (tsp *tailSamplingSpanProcessor) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	tsp.start.Do(func() {
 		tsp.logger.Info("First trace data arrived, starting tail-sampling timers")
 		tsp.policyTicker.Start(1 * time.Second)
@@ -306,13 +306,13 @@ func (tsp *tailSamplingSpanProcessor) dropTrace(traceID traceKey, deletionTime t
 	}
 }
 
-func prepareTraceBatch(spans []*tracepb.Span, singleTrace bool, td data.TraceData) data.TraceData {
-	var traceTd data.TraceData
+func prepareTraceBatch(spans []*tracepb.Span, singleTrace bool, td consumerdata.TraceData) consumerdata.TraceData {
+	var traceTd consumerdata.TraceData
 	if singleTrace {
 		// Special case no need to prepare a batch
 		traceTd = td
 	} else {
-		traceTd = data.TraceData{
+		traceTd = consumerdata.TraceData{
 			Node:     td.Node,
 			Resource: td.Resource,
 			Spans:    spans,

--- a/internal/collector/sampling/policy.go
+++ b/internal/collector/sampling/policy.go
@@ -20,7 +20,7 @@ import (
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 )
 
 // TraceData stores the sampling related trace data.
@@ -35,7 +35,7 @@ type TraceData struct {
 	// SpanCount track the number of spans on the trace.
 	SpanCount int64
 	// ReceivedBatches stores all the batches received for the trace.
-	ReceivedBatches []data.TraceData
+	ReceivedBatches []consumerdata.TraceData
 }
 
 // Decision gives the status of sampling decision.

--- a/processor/addattributesprocessor/addattributesprocessor.go
+++ b/processor/addattributesprocessor/addattributesprocessor.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cast"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/processor"
 )
 
@@ -89,7 +89,7 @@ func NewTraceProcessor(nextConsumer consumer.TraceConsumer, options ...Option) (
 	return aap, nil
 }
 
-func (aap *addattributesprocessor) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (aap *addattributesprocessor) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	if len(aap.attributeMap) == 0 {
 		return aap.nextConsumer.ConsumeTraceData(ctx, td)
 	}

--- a/processor/addattributesprocessor/addattributesprocessor_test.go
+++ b/processor/addattributesprocessor/addattributesprocessor_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
 )
 
@@ -41,7 +41,7 @@ func TestAddAttributesProcessorWithEmptyMap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when creating: want nil got %v", err)
 	}
-	if got := tt.ConsumeTraceData(context.Background(), data.TraceData{}); got != want {
+	if got := tt.ConsumeTraceData(context.Background(), consumerdata.TraceData{}); got != want {
 		t.Fatalf("ConsumeTraceData return error: want %v got %v", want, got)
 	}
 }
@@ -52,7 +52,7 @@ func TestAddAttributesProcessorWithEmptyMapReturnsError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when creating: want nil got %v", err)
 	}
-	if got := tt.ConsumeTraceData(context.Background(), data.TraceData{}); got != want {
+	if got := tt.ConsumeTraceData(context.Background(), consumerdata.TraceData{}); got != want {
 		t.Fatalf("ConsumeTraceData return error: want %v got %v", want, got)
 	}
 }
@@ -73,7 +73,7 @@ func TestAddAttributesProcessorNoAttributesAndNilSpan(t *testing.T) {
 		t.Fatalf("Unexpected error when creating: want nil got %v", err)
 	}
 
-	td := data.TraceData{}
+	td := consumerdata.TraceData{}
 	td.Spans = append(td.Spans, nil, &tracepb.Span{
 		Name: &tracepb.TruncatableString{Value: "foo"},
 	})
@@ -135,7 +135,7 @@ func addAttributesProcessorTestHelper(t *testing.T, overwrite bool) {
 		t.Fatalf("Unexpected error when creating: want nil got %v", err)
 	}
 
-	td := data.TraceData{}
+	td := consumerdata.TraceData{}
 	for i := 0; i < 7; i++ {
 		td.Spans = append(td.Spans, &tracepb.Span{
 			Attributes: &tracepb.Span_Attributes{

--- a/processor/attributekeyprocessor/attributekeyprocessor.go
+++ b/processor/attributekeyprocessor/attributekeyprocessor.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/processor"
 )
 
@@ -72,7 +72,7 @@ func NewTraceProcessor(nextConsumer consumer.TraceConsumer, replacements ...KeyR
 	}, nil
 }
 
-func (akp *attributekeyprocessor) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (akp *attributekeyprocessor) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	if len(akp.replacements) == 0 {
 		return akp.nextConsumer.ConsumeTraceData(ctx, td)
 	}

--- a/processor/attributekeyprocessor/attributekeyprocessor_test.go
+++ b/processor/attributekeyprocessor/attributekeyprocessor_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-service/processor"
 	"github.com/open-telemetry/opentelemetry-service/processor/processortest"
@@ -140,12 +140,12 @@ func Test_attributekeyprocessor_ConsumeTraceData(t *testing.T) {
 	tests := []struct {
 		name string
 		args []KeyReplacement
-		td   data.TraceData
-		want []data.TraceData
+		td   consumerdata.TraceData
+		want []consumerdata.TraceData
 	}{
 		{
 			name: "keyMap_nil",
-			want: []data.TraceData{
+			want: []consumerdata.TraceData{
 				{},
 			},
 		},
@@ -157,10 +157,10 @@ func Test_attributekeyprocessor_ConsumeTraceData(t *testing.T) {
 					NewKey: "bar",
 				},
 			},
-			td: data.TraceData{
+			td: consumerdata.TraceData{
 				Spans: make([]*tracepb.Span, 1, 1),
 			},
-			want: []data.TraceData{
+			want: []consumerdata.TraceData{
 				{
 					Spans: make([]*tracepb.Span, 1, 1),
 				},
@@ -174,14 +174,14 @@ func Test_attributekeyprocessor_ConsumeTraceData(t *testing.T) {
 					NewKey: "bar",
 				},
 			},
-			td: data.TraceData{
+			td: consumerdata.TraceData{
 				Spans: []*tracepb.Span{
 					{
 						Name: &tracepb.TruncatableString{Value: "test"},
 					},
 				},
 			},
-			want: []data.TraceData{
+			want: []consumerdata.TraceData{
 				{
 					Spans: []*tracepb.Span{
 						{
@@ -199,7 +199,7 @@ func Test_attributekeyprocessor_ConsumeTraceData(t *testing.T) {
 					NewKey: "bar",
 				},
 			},
-			td: data.TraceData{
+			td: consumerdata.TraceData{
 				Spans: []*tracepb.Span{
 					{
 						Name:       &tracepb.TruncatableString{Value: "test"},
@@ -207,7 +207,7 @@ func Test_attributekeyprocessor_ConsumeTraceData(t *testing.T) {
 					},
 				},
 			},
-			want: []data.TraceData{
+			want: []consumerdata.TraceData{
 				{
 					Spans: []*tracepb.Span{
 						{
@@ -242,7 +242,7 @@ func Test_attributekeyprocessor_ConsumeTraceData(t *testing.T) {
 					KeepOriginal: true,
 				},
 			},
-			td: data.TraceData{
+			td: consumerdata.TraceData{
 				Spans: []*tracepb.Span{
 					{
 						Name: &tracepb.TruncatableString{Value: "test"},
@@ -274,7 +274,7 @@ func Test_attributekeyprocessor_ConsumeTraceData(t *testing.T) {
 					},
 				},
 			},
-			want: []data.TraceData{
+			want: []consumerdata.TraceData{
 				{
 					Spans: []*tracepb.Span{
 						{

--- a/processor/multiconsumer/multiconsumer.go
+++ b/processor/multiconsumer/multiconsumer.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/internal"
 	"github.com/open-telemetry/opentelemetry-service/processor"
 )
@@ -33,7 +33,7 @@ type metricsConsumers []consumer.MetricsConsumer
 var _ processor.MetricsProcessor = (*metricsConsumers)(nil)
 
 // ConsumeMetricsData exports the MetricsData to all consumers wrapped by the current one.
-func (mcs metricsConsumers) ConsumeMetricsData(ctx context.Context, md data.MetricsData) error {
+func (mcs metricsConsumers) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
 	var errs []error
 	for _, mdp := range mcs {
 		if err := mdp.ConsumeMetricsData(ctx, md); err != nil {
@@ -53,7 +53,7 @@ type traceConsumers []consumer.TraceConsumer
 var _ processor.TraceProcessor = (*traceConsumers)(nil)
 
 // ConsumeTraceData exports the span data to all trace consumers wrapped by the current one.
-func (tcs traceConsumers) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (tcs traceConsumers) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	var errs []error
 	for _, tdp := range tcs {
 		if err := tdp.ConsumeTraceData(ctx, td); err != nil {

--- a/processor/multiconsumer/multiconsumer_test.go
+++ b/processor/multiconsumer/multiconsumer_test.go
@@ -21,7 +21,7 @@ import (
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 )
 
 func TestTraceProcessorMultiplexing(t *testing.T) {
@@ -31,7 +31,7 @@ func TestTraceProcessorMultiplexing(t *testing.T) {
 	}
 
 	tdp := NewTraceProcessor(processors)
-	td := data.TraceData{
+	td := consumerdata.TraceData{
 		Spans: make([]*tracepb.Span, 7),
 	}
 
@@ -64,7 +64,7 @@ func TestTraceProcessorWhenOneErrors(t *testing.T) {
 	processors[1].(*mockTraceConsumer).MustFail = true
 
 	tdp := NewTraceProcessor(processors)
-	td := data.TraceData{
+	td := consumerdata.TraceData{
 		Spans: make([]*tracepb.Span, 5),
 	}
 
@@ -94,7 +94,7 @@ func TestMetricsProcessorMultiplexing(t *testing.T) {
 	}
 
 	mdp := NewMetricsProcessor(processors)
-	md := data.MetricsData{
+	md := consumerdata.MetricsData{
 		Metrics: make([]*metricspb.Metric, 7),
 	}
 
@@ -127,7 +127,7 @@ func TestMetricsProcessorWhenOneErrors(t *testing.T) {
 	processors[1].(*mockMetricsConsumer).MustFail = true
 
 	mdp := NewMetricsProcessor(processors)
-	md := data.MetricsData{
+	md := consumerdata.MetricsData{
 		Metrics: make([]*metricspb.Metric, 5),
 	}
 
@@ -157,7 +157,7 @@ type mockTraceConsumer struct {
 
 var _ consumer.TraceConsumer = &mockTraceConsumer{}
 
-func (p *mockTraceConsumer) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (p *mockTraceConsumer) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	p.TotalSpans += len(td.Spans)
 	if p.MustFail {
 		return fmt.Errorf("this processor must fail")
@@ -173,7 +173,7 @@ type mockMetricsConsumer struct {
 
 var _ consumer.MetricsConsumer = &mockMetricsConsumer{}
 
-func (p *mockMetricsConsumer) ConsumeMetricsData(ctx context.Context, td data.MetricsData) error {
+func (p *mockMetricsConsumer) ConsumeMetricsData(ctx context.Context, td consumerdata.MetricsData) error {
 	p.TotalMetrics += len(td.Metrics)
 	if p.MustFail {
 		return fmt.Errorf("this processor must fail")

--- a/processor/processortest/nop_processor.go
+++ b/processor/processortest/nop_processor.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/processor"
 )
 
@@ -30,11 +30,11 @@ type nopProcessor struct {
 var _ processor.TraceProcessor = (*nopProcessor)(nil)
 var _ processor.MetricsProcessor = (*nopProcessor)(nil)
 
-func (np *nopProcessor) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (np *nopProcessor) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	return np.nextTraceProcessor.ConsumeTraceData(ctx, td)
 }
 
-func (np *nopProcessor) ConsumeMetricsData(ctx context.Context, md data.MetricsData) error {
+func (np *nopProcessor) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
 	return np.nextMetricsProcessor.ConsumeMetricsData(ctx, md)
 }
 

--- a/processor/processortest/nop_processor_test.go
+++ b/processor/processortest/nop_processor_test.go
@@ -20,14 +20,14 @@ import (
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
 )
 
 func TestNopTraceProcessorNoErrors(t *testing.T) {
 	sink := new(exportertest.SinkTraceExporter)
 	ntp := NewNopTraceProcessor(sink)
-	want := data.TraceData{
+	want := consumerdata.TraceData{
 		Spans: make([]*tracepb.Span, 7),
 	}
 	if err := ntp.ConsumeTraceData(context.Background(), want); err != nil {
@@ -43,7 +43,7 @@ func TestNopTraceProcessorNoErrors(t *testing.T) {
 func TestNopMetricsProcessorNoErrors(t *testing.T) {
 	sink := new(exportertest.SinkMetricsExporter)
 	nmp := NewNopMetricsProcessor(sink)
-	want := data.MetricsData{
+	want := consumerdata.MetricsData{
 		Metrics: make([]*metricspb.Metric, 7),
 	}
 	if err := nmp.ConsumeMetricsData(context.Background(), want); err != nil {

--- a/processor/tracesamplerprocessor/tracesamplerprocessor.go
+++ b/processor/tracesamplerprocessor/tracesamplerprocessor.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/processor"
 )
 
@@ -86,13 +86,13 @@ func NewTraceProcessor(nextConsumer consumer.TraceConsumer, cfg TraceSamplerCfg)
 	}, nil
 }
 
-func (tsp *tracesamplerprocessor) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (tsp *tracesamplerprocessor) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	scaledSamplingRate := tsp.scaledSamplingRate
 	if scaledSamplingRate >= numHashBuckets {
 		return tsp.nextConsumer.ConsumeTraceData(ctx, td)
 	}
 
-	sampledTraceData := data.TraceData{
+	sampledTraceData := consumerdata.TraceData{
 		Node:         td.Node,
 		Resource:     td.Resource,
 		SourceFormat: td.SourceFormat,

--- a/processor/tracesamplerprocessor/tracesamplerprocessor_test.go
+++ b/processor/tracesamplerprocessor/tracesamplerprocessor_test.go
@@ -26,7 +26,7 @@ import (
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
 	processormetrics "github.com/open-telemetry/opentelemetry-service/internal/collector/processor"
 	"github.com/open-telemetry/opentelemetry-service/processor"
@@ -270,10 +270,10 @@ func Test_hash(t *testing.T) {
 	}
 }
 
-// genRandomTestData generates a slice of data.TraceData with the numBatches elements which one with
+// genRandomTestData generates a slice of consumerdata.TraceData with the numBatches elements which one with
 // numTracesPerBatch spans (ie.: each span has a different trace ID). All spans belong to the specified
 // serviceName.
-func genRandomTestData(numBatches, numTracesPerBatch int, serviceName string) (tdd []data.TraceData) {
+func genRandomTestData(numBatches, numTracesPerBatch int, serviceName string) (tdd []consumerdata.TraceData) {
 	r := rand.New(rand.NewSource(1))
 
 	for i := 0; i < numBatches; i++ {
@@ -284,7 +284,7 @@ func genRandomTestData(numBatches, numTracesPerBatch int, serviceName string) (t
 			}
 			spans = append(spans, span)
 		}
-		td := data.TraceData{
+		td := consumerdata.TraceData{
 			Node: &commonpb.Node{
 				ServiceInfo: &commonpb.ServiceInfo{Name: serviceName},
 			},
@@ -298,7 +298,7 @@ func genRandomTestData(numBatches, numTracesPerBatch int, serviceName string) (t
 
 // assertSampledData checks for no repeated traceIDs and counts the number of spans on the sampled data for
 // the given service.
-func assertSampledData(t *testing.T, sampled []data.TraceData, serviceName string) (traceIDs map[string]bool, spanCount int) {
+func assertSampledData(t *testing.T, sampled []consumerdata.TraceData, serviceName string) (traceIDs map[string]bool, spanCount int) {
 	traceIDs = make(map[string]bool)
 	for _, td := range sampled {
 		if processormetrics.ServiceNameForNode(td.Node) != serviceName {

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"go.opencensus.io/trace"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-service/internal"
 	"github.com/open-telemetry/opentelemetry-service/receiver/receivertest"
@@ -145,7 +145,7 @@ func testJaegerAgent(t *testing.T, agentEndpoint string, receiverConfig *Configu
 
 	got := sink.AllTraces()
 
-	want := []data.TraceData{
+	want := []consumerdata.TraceData{
 		{
 			Node: &commonpb.Node{
 				ServiceInfo: &commonpb.ServiceInfo{Name: "issaTest"},

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"go.opencensus.io/trace"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-service/internal"
 	"github.com/open-telemetry/opentelemetry-service/receiver/receivertest"
@@ -129,7 +129,7 @@ func TestReception(t *testing.T) {
 
 	got := sink.AllTraces()
 
-	want := []data.TraceData{
+	want := []consumerdata.TraceData{
 		{
 			Node: &commonpb.Node{
 				ServiceInfo: &commonpb.ServiceInfo{Name: "issaTest"},

--- a/receiver/opencensusreceiver/ocmetrics/opencensus.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus.go
@@ -28,7 +28,7 @@ import (
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/observability"
 )
 
@@ -63,7 +63,7 @@ func (ocr *Receiver) Export(mes agentmetricspb.MetricsService_ExportServer) erro
 	// The bundler will receive batches of metrics i.e. []*metricspb.Metric
 	// We need to ensure that it propagates the receiver name as a tag
 	ctxWithReceiverName := observability.ContextWithReceiverName(mes.Context(), receiverTagValue)
-	metricsBundler := bundler.NewBundler((*data.MetricsData)(nil), func(payload interface{}) {
+	metricsBundler := bundler.NewBundler((*consumerdata.MetricsData)(nil), func(payload interface{}) {
 		ocr.batchMetricExporting(ctxWithReceiverName, payload)
 	})
 
@@ -118,13 +118,13 @@ func (ocr *Receiver) Export(mes agentmetricspb.MetricsService_ExportServer) erro
 func processReceivedMetrics(ni *commonpb.Node, resource *resourcepb.Resource, metrics []*metricspb.Metric, bundler *bundler.Bundler) {
 	// Firstly, we'll add them to the bundler.
 	if len(metrics) > 0 {
-		bundlerPayload := &data.MetricsData{Node: ni, Metrics: metrics, Resource: resource}
+		bundlerPayload := &consumerdata.MetricsData{Node: ni, Metrics: metrics, Resource: resource}
 		bundler.Add(bundlerPayload, len(bundlerPayload.Metrics))
 	}
 }
 
 func (ocr *Receiver) batchMetricExporting(longLivedRPCCtx context.Context, payload interface{}) {
-	mds := payload.([]*data.MetricsData)
+	mds := payload.([]*consumerdata.MetricsData)
 	if len(mds) == 0 {
 		return
 	}

--- a/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
@@ -35,7 +35,7 @@ import (
 	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/internal"
 	"github.com/open-telemetry/opentelemetry-service/observability"
 )
@@ -332,7 +332,7 @@ func newMetricAppender() *metricAppender {
 
 var _ consumer.MetricsConsumer = (*metricAppender)(nil)
 
-func (sa *metricAppender) ConsumeMetricsData(ctx context.Context, md data.MetricsData) error {
+func (sa *metricAppender) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
 	sa.Lock()
 	defer sa.Unlock()
 

--- a/receiver/opencensusreceiver/octrace/opencensus.go
+++ b/receiver/opencensusreceiver/octrace/opencensus.go
@@ -25,7 +25,7 @@ import (
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/observability"
 )
 
@@ -44,7 +44,7 @@ type Receiver struct {
 }
 
 type traceDataWithCtx struct {
-	data *data.TraceData
+	data *consumerdata.TraceData
 	ctx  context.Context
 }
 
@@ -122,7 +122,7 @@ func (ocr *Receiver) Export(tes agenttracepb.TraceService_ExportServer) error {
 			resource = recv.Resource
 		}
 
-		td := &data.TraceData{
+		td := &consumerdata.TraceData{
 			Node:         lastNonNilNode,
 			Resource:     resource,
 			Spans:        recv.Spans,
@@ -180,7 +180,7 @@ func (rw *receiverWorker) stopListening() {
 	close(rw.cancel)
 }
 
-func (rw *receiverWorker) export(longLivedCtx context.Context, tracedata *data.TraceData) {
+func (rw *receiverWorker) export(longLivedCtx context.Context, tracedata *consumerdata.TraceData) {
 	if tracedata == nil {
 		return
 	}

--- a/receiver/opencensusreceiver/octrace/opencensus_test.go
+++ b/receiver/opencensusreceiver/octrace/opencensus_test.go
@@ -37,7 +37,7 @@ import (
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/internal"
 	"github.com/open-telemetry/opentelemetry-service/observability"
 	"go.opencensus.io/trace"
@@ -466,7 +466,7 @@ func newSpanAppender() *spanAppender {
 
 var _ consumer.TraceConsumer = (*spanAppender)(nil)
 
-func (sa *spanAppender) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (sa *spanAppender) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	sa.Lock()
 	defer sa.Unlock()
 

--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-service/internal"
 	"github.com/open-telemetry/opentelemetry-service/receiver/receivertest"
@@ -114,7 +114,7 @@ func TestGrpcGateway_endToEnd(t *testing.T) {
 
 	got := sink.AllTraces()
 
-	want := []data.TraceData{
+	want := []consumerdata.TraceData{
 		{
 			Node: &commonpb.Node{
 				Identifier: &commonpb.ProcessIdentifier{HostName: "testHost"},

--- a/receiver/prometheusreceiver/internal/internal_test.go
+++ b/receiver/prometheusreceiver/internal/internal_test.go
@@ -17,7 +17,7 @@ package internal
 import (
 	"context"
 	"errors"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/scrape"
 	"go.uber.org/zap"
@@ -50,16 +50,16 @@ func (m *mockMetadataCache) SharedLabels() labels.Labels {
 
 func newMockConsumer() *mockConsumer {
 	return &mockConsumer{
-		Metrics: make(chan *data.MetricsData, 1),
+		Metrics: make(chan *consumerdata.MetricsData, 1),
 	}
 }
 
 type mockConsumer struct {
-	Metrics    chan *data.MetricsData
+	Metrics    chan *consumerdata.MetricsData
 	consumOnce sync.Once
 }
 
-func (m *mockConsumer) ConsumeMetricsData(ctx context.Context, md data.MetricsData) error {
+func (m *mockConsumer) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
 	m.consumOnce.Do(func() {
 		m.Metrics <- &md
 	})

--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -26,7 +26,7 @@ import (
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/textparse"
@@ -41,7 +41,7 @@ var trimmableSuffixes = []string{metricsSuffixBucket, metricsSuffixCount, metric
 var errNoDataToBuild = errors.New("there's no data to build")
 var errNoBoundaryLabel = errors.New("given metricType has no BucketLabel or QuantileLabel")
 var errEmptyBoundaryLabel = errors.New("BucketLabel or QuantileLabel is empty")
-var dummyMetric = &data.MetricsData{
+var dummyMetric = &consumerdata.MetricsData{
 	Node: &commonpb.Node{
 		Identifier:  &commonpb.ProcessIdentifier{HostName: "127.0.0.1"},
 		ServiceInfo: &commonpb.ServiceInfo{Name: "internal"},
@@ -82,7 +82,7 @@ type dataPointGroupMetadata struct {
 }
 
 // newMetricBuilder creates a MetricBuilder which is allowed to feed all the datapoints from a single prometheus
-// scraped page by calling its AddDataPoint function, and turn them into an opencensus data.MetricsData object
+// scraped page by calling its AddDataPoint function, and turn them into an opencensus consumerdata.MetricsData object
 // by calling its Build function
 func newMetricBuilder(node *commonpb.Node, mc MetadataCache, logger *zap.SugaredLogger) *metricBuilder {
 
@@ -165,8 +165,8 @@ func (b *metricBuilder) AddDataPoint(ls labels.Labels, t int64, v float64) error
 	return nil
 }
 
-// Build is to build an opencensus data.MetricsData based on all added data points
-func (b *metricBuilder) Build() (*data.MetricsData, error) {
+// Build is to build an opencensus consumerdata.MetricsData based on all added data points
+func (b *metricBuilder) Build() (*consumerdata.MetricsData, error) {
 	if !b.hasData {
 		if b.hasInternalMetric {
 			return dummyMetric, nil
@@ -177,7 +177,7 @@ func (b *metricBuilder) Build() (*data.MetricsData, error) {
 	if err := b.completeCurrentMetric(); err != nil {
 		return nil, err
 	}
-	return &data.MetricsData{
+	return &consumerdata.MetricsData{
 		Node:    b.node,
 		Metrics: b.metrics,
 	}, nil

--- a/receiver/prometheusreceiver/internal/ocastore_test.go
+++ b/receiver/prometheusreceiver/internal/ocastore_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/go-kit/kit/log"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/prometheus/prometheus/discovery"
 	"net/http"
 	"net/http/httptest"
@@ -141,7 +141,7 @@ func TestOcaStoreIntegration(t *testing.T) {
 			mc, cancel := startScraper(target.Host)
 			defer cancel()
 
-			var d *data.MetricsData
+			var d *consumerdata.MetricsData
 			select {
 			case d = <-mc.Metrics:
 			case <-time.After(time.Second * 10):

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -34,7 +34,7 @@ import (
 	"go.opencensus.io/metric/metricproducer"
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-service/internal/config/viperutils"
 	"github.com/open-telemetry/opentelemetry-service/receiver/receivertest"
@@ -206,7 +206,7 @@ buffer_count: 2
 	retrievedTimestamps := indexTimestampsByMetricDescriptorName(got)
 
 	// Now compare the received metrics data with what we expect.
-	want1 := []data.MetricsData{
+	want1 := []consumerdata.MetricsData{
 		{
 			Node: &commonpb.Node{
 				Identifier: &commonpb.ProcessIdentifier{
@@ -297,7 +297,7 @@ buffer_count: 2
 		},
 	}
 
-	want2 := []data.MetricsData{
+	want2 := []consumerdata.MetricsData{
 		{
 			Node: &commonpb.Node{
 				Identifier: &commonpb.ProcessIdentifier{
@@ -400,7 +400,7 @@ buffer_count: 2
 
 	// Since these tests rely on underdeterministic behavior and timing that's imprecise.
 	// The best that we can do is provide any of variants of what we want.
-	wantPermutations := [][]data.MetricsData{
+	wantPermutations := [][]consumerdata.MetricsData{
 		want1, want2,
 	}
 
@@ -412,7 +412,7 @@ buffer_count: 2
 	}
 }
 
-func byMetricsSorter(t *testing.T, mds []data.MetricsData) {
+func byMetricsSorter(t *testing.T, mds []consumerdata.MetricsData) {
 	for i, md := range mds {
 		eMetrics := md.Metrics
 		sort.Slice(eMetrics, func(i, j int) bool {
@@ -430,7 +430,7 @@ func byMetricsSorter(t *testing.T, mds []data.MetricsData) {
 	})
 }
 
-func indexTimestampsByMetricDescriptorName(mds []data.MetricsData) map[string]*timestamp.Timestamp {
+func indexTimestampsByMetricDescriptorName(mds []consumerdata.MetricsData) map[string]*timestamp.Timestamp {
 	index := make(map[string]*timestamp.Timestamp)
 	for _, md := range mds {
 		for _, eimetric := range md.Metrics {

--- a/receiver/vmmetricsreceiver/vm_metrics_collector.go
+++ b/receiver/vmmetricsreceiver/vm_metrics_collector.go
@@ -26,7 +26,7 @@ import (
 	"go.opencensus.io/trace"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/internal"
 
 	"contrib.go.opencensus.io/resource/auto"
@@ -220,7 +220,7 @@ func (vmc *VMMetricsCollector) scrapeAndExport() {
 	}
 
 	if len(metrics) > 0 {
-		vmc.consumer.ConsumeMetricsData(ctx, data.MetricsData{Metrics: metrics})
+		vmc.consumer.ConsumeMetricsData(ctx, consumerdata.MetricsData{Metrics: metrics})
 	}
 }
 

--- a/receiver/zipkinreceiver/factory_test.go
+++ b/receiver/zipkinreceiver/factory_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/models"
 	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
@@ -36,7 +36,9 @@ func TestCreateDefaultConfig(t *testing.T) {
 type mockTraceConsumer struct {
 }
 
-func (m *mockTraceConsumer) ConsumeTraceData(ctx context.Context, td data.TraceData) error { return nil }
+func (m *mockTraceConsumer) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
+	return nil
+}
 
 func TestCreateReceiver(t *testing.T) {
 	factory := receiver.GetReceiverFactory(typeStr)

--- a/receiver/zipkinreceiver/proto_parse_test.go
+++ b/receiver/zipkinreceiver/proto_parse_test.go
@@ -25,7 +25,7 @@ import (
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/internal"
 )
 
@@ -113,7 +113,7 @@ func TestConvertSpansToTraceSpans_protobuf(t *testing.T) {
 		t.Fatalf("Expecting exactly 2 requests since spans have different node/localEndpoint: %v", g)
 	}
 
-	want := []data.TraceData{
+	want := []consumerdata.TraceData{
 		{
 			Node: &commonpb.Node{
 				ServiceInfo: &commonpb.ServiceInfo{

--- a/receiver/zipkinreceiver/trace_receiver.go
+++ b/receiver/zipkinreceiver/trace_receiver.go
@@ -38,7 +38,7 @@ import (
 	"go.opencensus.io/trace"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/internal"
 	"github.com/open-telemetry/opentelemetry-service/observability"
 	"github.com/open-telemetry/opentelemetry-service/receiver"
@@ -128,7 +128,7 @@ func (zr *ZipkinReceiver) StartTraceReception(host receiver.Host) error {
 }
 
 // v1ToTraceSpans parses Zipkin v1 JSON traces and converts them to OpenCensus Proto spans.
-func (zr *ZipkinReceiver) v1ToTraceSpans(blob []byte, hdr http.Header) (reqs []data.TraceData, err error) {
+func (zr *ZipkinReceiver) v1ToTraceSpans(blob []byte, hdr http.Header) (reqs []consumerdata.TraceData, err error) {
 	if hdr.Get("Content-Type") == "application/x-thrift" {
 		zSpans, err := deserializeThrift(blob)
 		if err != nil {
@@ -169,7 +169,7 @@ func deserializeThrift(b []byte) ([]*zipkincore.Span, error) {
 }
 
 // v2ToTraceSpans parses Zipkin v2 JSON or Protobuf traces and converts them to OpenCensus Proto spans.
-func (zr *ZipkinReceiver) v2ToTraceSpans(blob []byte, hdr http.Header) (reqs []data.TraceData, err error) {
+func (zr *ZipkinReceiver) v2ToTraceSpans(blob []byte, hdr http.Header) (reqs []consumerdata.TraceData, err error) {
 	// This flag's reference is from:
 	//      https://github.com/openzipkin/zipkin-go/blob/3793c981d4f621c0e3eb1457acffa2c1cc591384/proto/v2/zipkin.proto#L154
 	debugWasSet := hdr.Get("X-B3-Flags") == "1"
@@ -215,7 +215,7 @@ func (zr *ZipkinReceiver) v2ToTraceSpans(blob []byte, hdr http.Header) (reqs []d
 			// not to send blank spans.
 			continue
 		}
-		reqs = append(reqs, data.TraceData{
+		reqs = append(reqs, consumerdata.TraceData{
 			Node:  node,
 			Spans: spans,
 		})
@@ -306,7 +306,7 @@ func (zr *ZipkinReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Now deserialize and process the spans.
 	asZipkinv1 := r.URL != nil && strings.Contains(r.URL.Path, "api/v1/spans")
 
-	var tds []data.TraceData
+	var tds []consumerdata.TraceData
 
 	var receiverTagValue string
 	if asZipkinv1 {

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -34,7 +34,7 @@ import (
 	zhttp "github.com/openzipkin/zipkin-go/reporter/http"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-service/internal"
 	"github.com/open-telemetry/opentelemetry-service/internal/testutils"
@@ -293,7 +293,7 @@ func TestConversionRoundtrip(t *testing.T) {
 		t.Fatalf("Failed to parse and convert receiver JSON: %v", err)
 	}
 
-	wantProtoRequests := []data.TraceData{
+	wantProtoRequests := []consumerdata.TraceData{
 		{
 			Node: &commonpb.Node{
 				ServiceInfo: &commonpb.ServiceInfo{Name: "frontend"},

--- a/receiver/zipkinreceiver/zipkinscribereceiver/scribe_receiver_test.go
+++ b/receiver/zipkinreceiver/zipkinscribereceiver/scribe_receiver_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/omnition/scribe-go/if/scribe/gen-go/scribe"
 	"github.com/open-telemetry/opentelemetry-service/consumer"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
 )
 
@@ -210,7 +210,7 @@ func TestScribeReceiverServer(t *testing.T) {
 // TODO: Move this to processortest.
 type mockTraceSink struct {
 	wg           *sync.WaitGroup
-	receivedData []data.TraceData
+	receivedData []consumerdata.TraceData
 }
 
 func newMockTraceSink(numReceiveTraceDataCount int) *mockTraceSink {
@@ -218,13 +218,13 @@ func newMockTraceSink(numReceiveTraceDataCount int) *mockTraceSink {
 	wg.Add(numReceiveTraceDataCount)
 	return &mockTraceSink{
 		wg:           wg,
-		receivedData: make([]data.TraceData, 0, numReceiveTraceDataCount),
+		receivedData: make([]consumerdata.TraceData, 0, numReceiveTraceDataCount),
 	}
 }
 
 var _ consumer.TraceConsumer = (*mockTraceSink)(nil)
 
-func (m *mockTraceSink) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (m *mockTraceSink) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	m.receivedData = append(m.receivedData, td)
 	m.wg.Done()
 	return nil
@@ -234,7 +234,7 @@ func (m *mockTraceSink) Wait() {
 	m.wg.Wait()
 }
 
-var wantTraceData = data.TraceData{
+var wantTraceData = consumerdata.TraceData{
 	Node: &commonpb.Node{
 		ServiceInfo: &commonpb.ServiceInfo{Name: "zipkin-query"},
 		Attributes: map[string]string{

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/receiver"
 	"github.com/open-telemetry/opentelemetry-service/receiver/jaegerreceiver"
 	"github.com/open-telemetry/opentelemetry-service/receiver/opencensusreceiver"
@@ -176,7 +176,7 @@ type mockTraceConsumer struct {
 	spansReceived uint64
 }
 
-func (tc *mockTraceConsumer) ConsumeTraceData(ctx context.Context, td data.TraceData) error {
+func (tc *mockTraceConsumer) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	atomic.AddUint64(&tc.spansReceived, uint64(len(td.Spans)))
 
 	for _, span := range td.Spans {
@@ -204,7 +204,7 @@ func (tc *mockTraceConsumer) ConsumeTraceData(ctx context.Context, td data.Trace
 type mockMetricConsumer struct {
 }
 
-func (mc *mockMetricConsumer) ConsumeMetricsData(ctx context.Context, md data.MetricsData) error {
+func (mc *mockMetricConsumer) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
 	// Metrics backend is not implemented yet.
 	return nil
 }

--- a/translator/trace/jaeger/jaegerthrift_to_protospan.go
+++ b/translator/trace/jaeger/jaegerthrift_to_protospan.go
@@ -25,14 +25,14 @@ import (
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/internal"
 	tracetranslator "github.com/open-telemetry/opentelemetry-service/translator/trace"
 )
 
 // ThriftBatchToOCProto converts a single Jaeger Thrift batch of spans to a OC proto batch.
-func ThriftBatchToOCProto(jbatch *jaeger.Batch) (data.TraceData, error) {
-	ocbatch := data.TraceData{
+func ThriftBatchToOCProto(jbatch *jaeger.Batch) (consumerdata.TraceData, error) {
+	ocbatch := consumerdata.TraceData{
 		Node:  jProcessToOCProtoNode(jbatch.GetProcess()),
 		Spans: jSpansToOCProtoSpans(jbatch.GetSpans()),
 	}

--- a/translator/trace/jaeger/jaegerthrift_to_protospan_test.go
+++ b/translator/trace/jaeger/jaegerthrift_to_protospan_test.go
@@ -26,7 +26,7 @@ import (
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/internal/testutils"
 	tracetranslator "github.com/open-telemetry/opentelemetry-service/translator/trace"
 )
@@ -241,7 +241,7 @@ func TestConservativeConversions(t *testing.T) {
 		},
 	}
 
-	got := make([]data.TraceData, 0, len(batches))
+	got := make([]consumerdata.TraceData, 0, len(batches))
 	for i, batch := range batches {
 		gb, err := ThriftBatchToOCProto(batch)
 		if err != nil {
@@ -251,7 +251,7 @@ func TestConservativeConversions(t *testing.T) {
 		got = append(got, gb)
 	}
 
-	want := []data.TraceData{
+	want := []consumerdata.TraceData{
 		{
 			// The conversion returns a slice with capacity equals to the number of elements in the
 			// jager batch spans, even if the element is nil.

--- a/translator/trace/jaeger/protospan_to_jaegerproto.go
+++ b/translator/trace/jaeger/protospan_to_jaegerproto.go
@@ -25,7 +25,7 @@ import (
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	tracetranslator "github.com/open-telemetry/opentelemetry-service/translator/trace"
 )
 
@@ -34,7 +34,7 @@ var (
 )
 
 // OCProtoToJaegerProto translates OpenCensus trace data into the Jaeger Proto for GRPC.
-func OCProtoToJaegerProto(td data.TraceData) (*jaeger.Batch, error) {
+func OCProtoToJaegerProto(td consumerdata.TraceData) (*jaeger.Batch, error) {
 	jSpans, err := ocSpansToJaegerSpansProto(td.Spans)
 	if err != nil {
 		return nil, err

--- a/translator/trace/jaeger/protospan_to_jaegerproto_test.go
+++ b/translator/trace/jaeger/protospan_to_jaegerproto_test.go
@@ -26,13 +26,13 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 	jaeger "github.com/jaegertracing/jaeger/model"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/internal/testutils"
 	tracetranslator "github.com/open-telemetry/opentelemetry-service/translator/trace"
 )
 
 func TestNilOCProtoNodeToJaegerProto(t *testing.T) {
-	nilNodeBatch := data.TraceData{
+	nilNodeBatch := consumerdata.TraceData{
 		Spans: []*tracepb.Span{
 			{
 				TraceId: []byte("0123456789abcdef"),
@@ -301,7 +301,7 @@ func TestOCStatusToJaegerProtoTags(t *testing.T) {
 	fakeTraceID := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	fakeSpanID := []byte{0, 1, 2, 3, 4, 5, 6, 7}
 	for i, c := range cases {
-		gb, err := OCProtoToJaegerProto(data.TraceData{
+		gb, err := OCProtoToJaegerProto(consumerdata.TraceData{
 			Spans: []*tracepb.Span{{
 				TraceId:    fakeTraceID,
 				SpanId:     fakeSpanID,
@@ -326,7 +326,7 @@ func TestOCStatusToJaegerProtoTags(t *testing.T) {
 
 // ocBatches has the OpenCensus proto batches used in the test. They are hard coded because
 // structs like tracepb.AttributeMap cannot be read from JSON.
-var ocBatches = []data.TraceData{
+var ocBatches = []consumerdata.TraceData{
 	{
 		Node: &commonpb.Node{
 			Identifier: &commonpb.ProcessIdentifier{

--- a/translator/trace/jaeger/protospan_to_jaegerthrift.go
+++ b/translator/trace/jaeger/protospan_to_jaegerthrift.go
@@ -23,7 +23,7 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	tracetranslator "github.com/open-telemetry/opentelemetry-service/translator/trace"
 )
 
@@ -32,7 +32,7 @@ var (
 )
 
 // OCProtoToJaegerThrift translates OpenCensus trace data into the Jaeger Thrift format.
-func OCProtoToJaegerThrift(td data.TraceData) (*jaeger.Batch, error) {
+func OCProtoToJaegerThrift(td consumerdata.TraceData) (*jaeger.Batch, error) {
 	jSpans, err := ocSpansToJaegerSpans(td.Spans)
 	if err != nil {
 		return nil, err

--- a/translator/trace/jaeger/protospan_to_jaegerthrift_test.go
+++ b/translator/trace/jaeger/protospan_to_jaegerthrift_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/internal/testutils"
 	tracetranslator "github.com/open-telemetry/opentelemetry-service/translator/trace"
 )
@@ -93,7 +93,7 @@ func TestThriftInvalidOCProtoIDs(t *testing.T) {
 }
 
 func TestNilOCProtoNodeToJaegerThrift(t *testing.T) {
-	nilNodeBatch := data.TraceData{
+	nilNodeBatch := consumerdata.TraceData{
 		Spans: []*tracepb.Span{
 			{
 				TraceId: []byte("0123456789abcdef"),
@@ -358,7 +358,7 @@ func TestOCStatusToJaegerThriftTags(t *testing.T) {
 	fakeTraceID := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	fakeSpanID := []byte{0, 1, 2, 3, 4, 5, 6, 7}
 	for i, c := range cases {
-		gb, err := OCProtoToJaegerThrift(data.TraceData{
+		gb, err := OCProtoToJaegerThrift(consumerdata.TraceData{
 			Spans: []*tracepb.Span{{
 				TraceId:    fakeTraceID,
 				SpanId:     fakeSpanID,
@@ -382,7 +382,7 @@ func TestOCStatusToJaegerThriftTags(t *testing.T) {
 
 // tds has the TraceData proto used in the test. They are hard coded because
 // structs like tracepb.AttributeMap cannot be ready from JSON.
-var tds = []data.TraceData{
+var tds = []consumerdata.TraceData{
 	{
 		Node: &commonpb.Node{
 			Identifier: &commonpb.ProcessIdentifier{

--- a/translator/trace/zipkin/zipkinv1_thrift_to_protospan.go
+++ b/translator/trace/zipkin/zipkinv1_thrift_to_protospan.go
@@ -27,12 +27,12 @@ import (
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 	"github.com/pkg/errors"
 
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	tracetranslator "github.com/open-telemetry/opentelemetry-service/translator/trace"
 )
 
 // V1ThriftBatchToOCProto converts Zipkin v1 spans to OC Proto.
-func V1ThriftBatchToOCProto(zSpans []*zipkincore.Span) ([]data.TraceData, error) {
+func V1ThriftBatchToOCProto(zSpans []*zipkincore.Span) ([]consumerdata.TraceData, error) {
 	ocSpansAndParsedAnnotations := make([]ocSpanAndParsedAnnotations, 0, len(zSpans))
 	for _, zSpan := range zSpans {
 		ocSpan, parsedAnnotations, err := zipkinV1ThriftToOCSpan(zSpan)

--- a/translator/trace/zipkin/zipkinv1_to_protospan_test.go
+++ b/translator/trace/zipkin/zipkinv1_to_protospan_test.go
@@ -25,7 +25,7 @@ import (
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/open-telemetry/opentelemetry-service/data"
+	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	tracetranslator "github.com/open-telemetry/opentelemetry-service/translator/trace"
 )
 
@@ -197,8 +197,8 @@ func TestMultipleJSONV1BatchesToOCProto(t *testing.T) {
 		t.Fatalf("failed to load the batches: %v", err)
 	}
 
-	nodeToTraceReqs := make(map[string]*data.TraceData)
-	var got []data.TraceData
+	nodeToTraceReqs := make(map[string]*consumerdata.TraceData)
+	var got []consumerdata.TraceData
 	for _, batch := range batches {
 		jsonBatch, err := json.Marshal(batch)
 		if err != nil {
@@ -235,7 +235,7 @@ func TestMultipleJSONV1BatchesToOCProto(t *testing.T) {
 	}
 }
 
-func sortTraceByNodeName(trace []data.TraceData) {
+func sortTraceByNodeName(trace []consumerdata.TraceData) {
 	sort.Slice(trace, func(i, j int) bool {
 		return trace[i].Node.ServiceInfo.Name < trace[j].Node.ServiceInfo.Name
 	})
@@ -563,7 +563,7 @@ func TestJSONHTTPToGRPCStatusCode(t *testing.T) {
 
 // ocBatches has the OpenCensus proto batches used in the test. They are hard coded because
 // structs like tracepb.AttributeMap cannot be ready from JSON.
-var ocBatchesFromZipkinV1 = []data.TraceData{
+var ocBatchesFromZipkinV1 = []consumerdata.TraceData{
 	{
 		Node: &commonpb.Node{
 			ServiceInfo: &commonpb.ServiceInfo{Name: "front-proxy"},


### PR DESCRIPTION
Cleanup the root directory to have a more easier to read repository. The main user of data are the consumer interfaces so it is safe to assume that these are consumerdata.