### PR TITLE
Rename ConfigV2 structs to Config

### DIFF
--- a/cmd/occollector/app/builder/exporters_builder.go
+++ b/cmd/occollector/app/builder/exporters_builder.go
@@ -63,11 +63,11 @@ type exportersRequiredDataTypes map[configmodels.Exporter]dataTypeRequirements
 // ExportersBuilder builds exporters from config.
 type ExportersBuilder struct {
 	logger *zap.Logger
-	config *configmodels.ConfigV2
+	config *configmodels.Config
 }
 
 // NewExportersBuilder creates a new ExportersBuilder. Call Build() on the returned value.
-func NewExportersBuilder(logger *zap.Logger, config *configmodels.ConfigV2) *ExportersBuilder {
+func NewExportersBuilder(logger *zap.Logger, config *configmodels.Config) *ExportersBuilder {
 	return &ExportersBuilder{logger, config}
 }
 

--- a/cmd/occollector/app/builder/exporters_builder_test.go
+++ b/cmd/occollector/app/builder/exporters_builder_test.go
@@ -28,9 +28,9 @@ import (
 )
 
 func TestExportersBuilder_Build(t *testing.T) {
-	config := &configmodels.ConfigV2{
+	config := &configmodels.Config{
 		Exporters: map[string]configmodels.Exporter{
-			"opencensus": &opencensusexporter.ConfigV2{
+			"opencensus": &opencensusexporter.Config{
 				ExporterSettings: configmodels.ExporterSettings{
 					NameVal: "opencensus",
 					TypeVal: "opencensus",

--- a/cmd/occollector/app/builder/pipelines_builder.go
+++ b/cmd/occollector/app/builder/pipelines_builder.go
@@ -39,7 +39,7 @@ type PipelineProcessors map[*configmodels.Pipeline]*builtProcessor
 // PipelinesBuilder builds pipelines from config.
 type PipelinesBuilder struct {
 	logger    *zap.Logger
-	config    *configmodels.ConfigV2
+	config    *configmodels.Config
 	exporters Exporters
 }
 
@@ -47,7 +47,7 @@ type PipelinesBuilder struct {
 // built via ExportersBuilder. Call Build() on the returned value.
 func NewPipelinesBuilder(
 	logger *zap.Logger,
-	config *configmodels.ConfigV2,
+	config *configmodels.Config,
 	exporters Exporters,
 ) *PipelinesBuilder {
 	return &PipelinesBuilder{logger, config, exporters}

--- a/cmd/occollector/app/builder/pipelines_builder_test.go
+++ b/cmd/occollector/app/builder/pipelines_builder_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Ensure attributes processor is registered.
-var _ = addattributesprocessor.ConfigV2{}
+var _ = addattributesprocessor.Config{}
 
 // Register test factories used in the pipelines_builder.yaml test config.
 var _ = config.RegisterTestFactories()

--- a/cmd/occollector/app/builder/receivers_builder.go
+++ b/cmd/occollector/app/builder/receivers_builder.go
@@ -101,14 +101,14 @@ func (rcvs Receivers) StartAll(logger *zap.Logger, host receiver.Host) error {
 // ReceiversBuilder builds receivers from config.
 type ReceiversBuilder struct {
 	logger             *zap.Logger
-	config             *configmodels.ConfigV2
+	config             *configmodels.Config
 	pipelineProcessors PipelineProcessors
 }
 
 // NewReceiversBuilder creates a new ReceiversBuilder. Call Build() on the returned value.
 func NewReceiversBuilder(
 	logger *zap.Logger,
-	config *configmodels.ConfigV2,
+	config *configmodels.Config,
 	pipelineProcessors PipelineProcessors,
 ) *ReceiversBuilder {
 	return &ReceiversBuilder{logger, config, pipelineProcessors}

--- a/config/configmodels/configmodels.go
+++ b/config/configmodels/configmodels.go
@@ -14,7 +14,7 @@
 
 // Package configmodels defines the data models for entities. This file defines the
 // models for V2 configuration format. The defined entities are:
-// ConfigV2 (the top-level structure), Receivers, Exporters, Processors, Pipelines.
+// Config (the top-level structure), Receivers, Exporters, Processors, Pipelines.
 package configmodels
 
 /*
@@ -31,8 +31,8 @@ corresponding interface and if they have additional settings they must also exte
 the corresponding common settings struct (the easiest approach is to embed the common struct).
 */
 
-// ConfigV2 defines the configuration V2 for the various elements of collector or agent.
-type ConfigV2 struct {
+// Config defines the configuration V2 for the various elements of collector or agent.
+type Config struct {
 	Receivers  Receivers
 	Exporters  Exporters
 	Processors Processors

--- a/config/configv2.go
+++ b/config/configv2.go
@@ -83,10 +83,10 @@ const (
 // typeAndNameSeparator is the separator that is used between type and name in type/name composite keys.
 const typeAndNameSeparator = "/"
 
-// Load loads a ConfigV2 from Viper.
-func Load(v *viper.Viper) (*configmodels.ConfigV2, error) {
+// Load loads a Config from Viper.
+func Load(v *viper.Viper) (*configmodels.Config, error) {
 
-	var config configmodels.ConfigV2
+	var config configmodels.Config
 
 	// Load the config.
 
@@ -402,7 +402,7 @@ func loadPipelines(v *viper.Viper) (configmodels.Pipelines, error) {
 	return pipelines, nil
 }
 
-func validateConfig(cfg *configmodels.ConfigV2) error {
+func validateConfig(cfg *configmodels.Config) error {
 	// This function performs basic validation of configuration. There may be more subtle
 	// invalid cases that we currently don't check for but which we may want to add in
 	// the future (e.g. disallowing receiving and exporting on the same endpoint).
@@ -414,7 +414,7 @@ func validateConfig(cfg *configmodels.ConfigV2) error {
 	return nil
 }
 
-func validatePipelines(cfg *configmodels.ConfigV2) error {
+func validatePipelines(cfg *configmodels.Config) error {
 	// Must have at least one pipeline.
 	if len(cfg.Pipelines) < 1 {
 		return &configError{code: errMissingPipelines, msg: "must have at least one pipeline"}
@@ -429,7 +429,7 @@ func validatePipelines(cfg *configmodels.ConfigV2) error {
 	return nil
 }
 
-func validatePipeline(cfg *configmodels.ConfigV2, pipeline *configmodels.Pipeline) error {
+func validatePipeline(cfg *configmodels.Config, pipeline *configmodels.Pipeline) error {
 	if err := validatePipelineReceivers(cfg, pipeline); err != nil {
 		return err
 	}
@@ -445,7 +445,7 @@ func validatePipeline(cfg *configmodels.ConfigV2, pipeline *configmodels.Pipelin
 	return nil
 }
 
-func validatePipelineReceivers(cfg *configmodels.ConfigV2, pipeline *configmodels.Pipeline) error {
+func validatePipelineReceivers(cfg *configmodels.Config, pipeline *configmodels.Pipeline) error {
 	if len(pipeline.Receivers) == 0 {
 		return &configError{
 			code: errPipelineMustHaveReceiver,
@@ -467,7 +467,7 @@ func validatePipelineReceivers(cfg *configmodels.ConfigV2, pipeline *configmodel
 	return nil
 }
 
-func validatePipelineExporters(cfg *configmodels.ConfigV2, pipeline *configmodels.Pipeline) error {
+func validatePipelineExporters(cfg *configmodels.Config, pipeline *configmodels.Pipeline) error {
 	if len(pipeline.Exporters) == 0 {
 		return &configError{
 			code: errPipelineMustHaveExporter,
@@ -489,7 +489,7 @@ func validatePipelineExporters(cfg *configmodels.ConfigV2, pipeline *configmodel
 	return nil
 }
 
-func validatePipelineProcessors(cfg *configmodels.ConfigV2, pipeline *configmodels.Pipeline) error {
+func validatePipelineProcessors(cfg *configmodels.Config, pipeline *configmodels.Pipeline) error {
 	if pipeline.InputType == configmodels.TracesDataType {
 		// Traces pipeline must have at least one processor.
 		if len(pipeline.Processors) == 0 {

--- a/config/test_helpers.go
+++ b/config/test_helpers.go
@@ -23,7 +23,7 @@ import (
 )
 
 // LoadConfigFile loads a config from file.
-func LoadConfigFile(t *testing.T, fileName string) (*configmodels.ConfigV2, error) {
+func LoadConfigFile(t *testing.T, fileName string) (*configmodels.Config, error) {
 	// Open the file for reading.
 	file, err := os.Open(fileName)
 	if err != nil {

--- a/exporter/loggingexporter/config.go
+++ b/exporter/loggingexporter/config.go
@@ -18,8 +18,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
 )
 
-// ConfigV2 defines configuration for logging exporter.
+// Config defines configuration for logging exporter.
 // TODO: allow configuration of logging level
-type ConfigV2 struct {
+type Config struct {
 	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 }

--- a/exporter/loggingexporter/config_test.go
+++ b/exporter/loggingexporter/config_test.go
@@ -41,7 +41,7 @@ func TestLoadConfig(t *testing.T) {
 
 	e1 := cfg.Exporters["logging/2"]
 	assert.Equal(t, e1,
-		&ConfigV2{
+		&Config{
 			ExporterSettings: configmodels.ExporterSettings{
 				NameVal: "logging/2",
 				TypeVal: "logging",

--- a/exporter/loggingexporter/factory.go
+++ b/exporter/loggingexporter/factory.go
@@ -40,7 +40,7 @@ func (f *factory) Type() string {
 
 // CreateDefaultConfig creates the default configuration for exporter.
 func (f *factory) CreateDefaultConfig() configmodels.Exporter {
-	return &ConfigV2{
+	return &Config{
 		ExporterSettings: configmodels.ExporterSettings{
 			TypeVal: typeStr,
 			NameVal: typeStr,

--- a/exporter/opencensusexporter/config.go
+++ b/exporter/opencensusexporter/config.go
@@ -20,8 +20,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
 )
 
-// ConfigV2 defines configuration for OpenCensus exporter.
-type ConfigV2 struct {
+// Config defines configuration for OpenCensus exporter.
+type Config struct {
 	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 	Endpoint                      string                   `mapstructure:"endpoint"`
 	Compression                   string                   `mapstructure:"compression"`

--- a/exporter/opencensusexporter/config_test.go
+++ b/exporter/opencensusexporter/config_test.go
@@ -41,7 +41,7 @@ func TestLoadConfig(t *testing.T) {
 
 	e1 := cfg.Exporters["opencensus/2"]
 	assert.Equal(t, e1,
-		&ConfigV2{
+		&Config{
 			ExporterSettings: configmodels.ExporterSettings{
 				NameVal: "opencensus/2",
 				TypeVal: "opencensus",

--- a/exporter/opencensusexporter/factory.go
+++ b/exporter/opencensusexporter/factory.go
@@ -51,7 +51,7 @@ func (f *factory) Type() string {
 
 // CreateDefaultConfig creates the default configuration for exporter.
 func (f *factory) CreateDefaultConfig() configmodels.Exporter {
-	return &ConfigV2{
+	return &Config{
 		ExporterSettings: configmodels.ExporterSettings{
 			TypeVal: typeStr,
 			NameVal: typeStr,
@@ -62,7 +62,7 @@ func (f *factory) CreateDefaultConfig() configmodels.Exporter {
 
 // CreateTraceExporter creates a trace exporter based on this config.
 func (f *factory) CreateTraceExporter(logger *zap.Logger, config configmodels.Exporter) (consumer.TraceConsumer, exporter.StopFunc, error) {
-	ocac := config.(*ConfigV2)
+	ocac := config.(*Config)
 
 	if ocac.Endpoint == "" {
 		return nil, nil, &ocTraceExporterError{

--- a/exporter/opencensusexporter/factory_test.go
+++ b/exporter/opencensusexporter/factory_test.go
@@ -56,7 +56,7 @@ func TestCreateTraceExporter(t *testing.T) {
 	// results. Standing up a receiver to ensure that stop don't report errors.
 	rcvFactory := receiver.GetFactory(typeStr)
 	require.NotNil(t, rcvFactory)
-	rcvCfg := rcvFactory.CreateDefaultConfig().(*opencensusreceiver.ConfigV2)
+	rcvCfg := rcvFactory.CreateDefaultConfig().(*opencensusreceiver.Config)
 	rcvCfg.Endpoint = testutils.GetAvailableLocalAddress(t)
 
 	rcv, err := rcvFactory.CreateTraceReceiver(
@@ -71,33 +71,33 @@ func TestCreateTraceExporter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		config   ConfigV2
+		config   Config
 		mustFail bool
 	}{
 		{
 			name: "NoEndpoint",
-			config: ConfigV2{
+			config: Config{
 				Endpoint: "",
 			},
 			mustFail: true,
 		},
 		{
 			name: "UseSecure",
-			config: ConfigV2{
+			config: Config{
 				Endpoint:  rcvCfg.Endpoint,
 				UseSecure: true,
 			},
 		},
 		{
 			name: "ReconnectionDelay",
-			config: ConfigV2{
+			config: Config{
 				Endpoint:          rcvCfg.Endpoint,
 				ReconnectionDelay: 5 * time.Second,
 			},
 		},
 		{
 			name: "KeepaliveParameters",
-			config: ConfigV2{
+			config: Config{
 				Endpoint: rcvCfg.Endpoint,
 				KeepaliveParameters: &keepaliveConfig{
 					Time:                30 * time.Second,
@@ -108,14 +108,14 @@ func TestCreateTraceExporter(t *testing.T) {
 		},
 		{
 			name: "Compression",
-			config: ConfigV2{
+			config: Config{
 				Endpoint:    rcvCfg.Endpoint,
 				Compression: compression.Gzip,
 			},
 		},
 		{
 			name: "Headers",
-			config: ConfigV2{
+			config: Config{
 				Endpoint: rcvCfg.Endpoint,
 				Headers: map[string]string{
 					"hdr1": "val1",
@@ -125,14 +125,14 @@ func TestCreateTraceExporter(t *testing.T) {
 		},
 		{
 			name: "NumWorkers",
-			config: ConfigV2{
+			config: Config{
 				Endpoint:   rcvCfg.Endpoint,
 				NumWorkers: 3,
 			},
 		},
 		{
 			name: "CompressionError",
-			config: ConfigV2{
+			config: Config{
 				Endpoint:    rcvCfg.Endpoint,
 				Compression: "unknown compression",
 			},
@@ -140,14 +140,14 @@ func TestCreateTraceExporter(t *testing.T) {
 		},
 		{
 			name: "CertPemFile",
-			config: ConfigV2{
+			config: Config{
 				Endpoint:    rcvCfg.Endpoint,
 				CertPemFile: "testdata/test_cert.pem",
 			},
 		},
 		{
 			name: "CertPemFileError",
-			config: ConfigV2{
+			config: Config{
 				Endpoint:    rcvCfg.Endpoint,
 				CertPemFile: "nosuchfile",
 			},

--- a/exporter/prometheusexporter/config.go
+++ b/exporter/prometheusexporter/config.go
@@ -20,8 +20,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
 )
 
-// ConfigV2 defines configuration for Prometheus exporter.
-type ConfigV2 struct {
+// Config defines configuration for Prometheus exporter.
+type Config struct {
 	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 
 	// The address on which the Prometheus scrape handler will be run on.

--- a/exporter/prometheusexporter/config_test.go
+++ b/exporter/prometheusexporter/config_test.go
@@ -41,7 +41,7 @@ func TestLoadConfig(t *testing.T) {
 
 	e1 := cfg.Exporters["prometheus/2"]
 	assert.Equal(t, e1,
-		&ConfigV2{
+		&Config{
 			ExporterSettings: configmodels.ExporterSettings{
 				NameVal: "prometheus/2",
 				TypeVal: "prometheus",

--- a/exporter/prometheusexporter/factory.go
+++ b/exporter/prometheusexporter/factory.go
@@ -46,7 +46,7 @@ func (f *factory) Type() string {
 
 // CreateDefaultConfig creates the default configuration for exporter.
 func (f *factory) CreateDefaultConfig() configmodels.Exporter {
-	return &ConfigV2{
+	return &Config{
 		ExporterSettings: configmodels.ExporterSettings{
 			TypeVal: typeStr,
 			NameVal: typeStr,
@@ -62,7 +62,7 @@ func (f *factory) CreateTraceExporter(logger *zap.Logger, config configmodels.Ex
 
 // CreateMetricsExporter creates a metrics exporter based on this config.
 func (f *factory) CreateMetricsExporter(logger *zap.Logger, cfg configmodels.Exporter) (consumer.MetricsConsumer, exporter.StopFunc, error) {
-	pcfg := cfg.(*ConfigV2)
+	pcfg := cfg.(*Config)
 
 	addr := strings.TrimSpace(pcfg.Endpoint)
 	if addr == "" {

--- a/exporter/prometheusexporter/factory_test.go
+++ b/exporter/prometheusexporter/factory_test.go
@@ -45,12 +45,12 @@ func TestCreateMetricsExporter(t *testing.T) {
 	const defaultTestEndPoint = "127.0.0.1:55678"
 	tests := []struct {
 		name     string
-		config   ConfigV2
+		config   Config
 		mustFail bool
 	}{
 		{
 			name: "NoEndpoint",
-			config: ConfigV2{
+			config: Config{
 				Endpoint: "",
 			},
 			mustFail: true,

--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -34,11 +34,11 @@ import (
 
 func TestPrometheusExporter(t *testing.T) {
 	tests := []struct {
-		config  *ConfigV2
+		config  *Config
 		wantErr string
 	}{
 		{
-			config: &ConfigV2{
+			config: &Config{
 				Namespace: "test",
 				ConstLabels: map[string]string{
 					"foo":  "bar",
@@ -48,7 +48,7 @@ func TestPrometheusExporter(t *testing.T) {
 			},
 		},
 		{
-			config:  &ConfigV2{},
+			config:  &Config{},
 			wantErr: "expecting a non-blank address to run the Prometheus metrics handler",
 		},
 	}
@@ -96,7 +96,7 @@ prometheus:`)
 }
 
 func TestPrometheusExporter_endToEnd(t *testing.T) {
-	config := &ConfigV2{
+	config := &Config{
 		Namespace: "test",
 		ConstLabels: map[string]string{
 			"foo":  "bar",

--- a/internal/collector/processor/nodebatcher/config.go
+++ b/internal/collector/processor/nodebatcher/config.go
@@ -20,8 +20,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
 )
 
-// ConfigV2 defines configuration for batch processor.
-type ConfigV2 struct {
+// Config defines configuration for batch processor.
+type Config struct {
 	configmodels.ProcessorSettings `mapstructure:",squash"`
 
 	// Timeout sets the time after which a batch will be sent regardless of size.

--- a/internal/collector/processor/nodebatcher/config_test.go
+++ b/internal/collector/processor/nodebatcher/config_test.go
@@ -49,7 +49,7 @@ func TestLoadConfig(t *testing.T) {
 	sendBatchSize := 1000
 
 	assert.Equal(t, p1,
-		&ConfigV2{
+		&Config{
 			ProcessorSettings: configmodels.ProcessorSettings{
 				TypeVal: "batch",
 				NameVal: "batch/2",

--- a/internal/collector/processor/nodebatcher/factory.go
+++ b/internal/collector/processor/nodebatcher/factory.go
@@ -46,7 +46,7 @@ func (f *factory) CreateDefaultConfig() configmodels.Processor {
 	tickTime := defaultTickTime
 	timeout := defaultTimeout
 
-	return &ConfigV2{
+	return &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			TypeVal: typeStr,
 			NameVal: typeStr,
@@ -65,7 +65,7 @@ func (f *factory) CreateTraceProcessor(
 	nextConsumer consumer.TraceConsumer,
 	c configmodels.Processor,
 ) (processor.TraceProcessor, error) {
-	cfg := c.(*ConfigV2)
+	cfg := c.(*Config)
 
 	var batchingOptions []Option
 	if cfg.Timeout != nil {

--- a/internal/collector/processor/queued/config.go
+++ b/internal/collector/processor/queued/config.go
@@ -20,8 +20,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
 )
 
-// ConfigV2 defines configuration for Attributes processor.
-type ConfigV2 struct {
+// Config defines configuration for Attributes processor.
+type Config struct {
 	configmodels.ProcessorSettings `mapstructure:",squash"`
 
 	// NumWorkers is the number of queue workers that dequeue batches and send them out.

--- a/internal/collector/processor/queued/config_test.go
+++ b/internal/collector/processor/queued/config_test.go
@@ -43,7 +43,7 @@ func TestLoadConfig(t *testing.T) {
 
 	p1 := cfg.Processors["queued-retry/2"]
 	assert.Equal(t, p1,
-		&ConfigV2{
+		&Config{
 			ProcessorSettings: configmodels.ProcessorSettings{
 				TypeVal: "queued-retry",
 				NameVal: "queued-retry/2",

--- a/internal/collector/processor/queued/factory.go
+++ b/internal/collector/processor/queued/factory.go
@@ -42,7 +42,7 @@ func (f *factory) Type() string {
 
 // CreateDefaultConfig creates the default configuration for exporter.
 func (f *factory) CreateDefaultConfig() configmodels.Processor {
-	return &ConfigV2{
+	return &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			TypeVal: typeStr,
 			NameVal: typeStr,
@@ -60,7 +60,7 @@ func (f *factory) CreateTraceProcessor(
 	nextConsumer consumer.TraceConsumer,
 	cfg configmodels.Processor,
 ) (processor.TraceProcessor, error) {
-	oCfg := cfg.(*ConfigV2)
+	oCfg := cfg.(*Config)
 	return NewQueuedSpanProcessor(nextConsumer,
 		Options.WithNumWorkers(oCfg.NumWorkers),
 		Options.WithQueueSize(oCfg.QueueSize),

--- a/processor/addattributesprocessor/config.go
+++ b/processor/addattributesprocessor/config.go
@@ -18,8 +18,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
 )
 
-// ConfigV2 defines configuration for Attributes processor.
-type ConfigV2 struct {
+// Config defines configuration for Attributes processor.
+type Config struct {
 	configmodels.ProcessorSettings `mapstructure:",squash"`
 	Overwrite                      bool                   `mapstructure:"overwrite"`
 	Values                         map[string]interface{} `mapstructure:"values"`

--- a/processor/addattributesprocessor/config_test.go
+++ b/processor/addattributesprocessor/config_test.go
@@ -42,7 +42,7 @@ func TestLoadConfig(t *testing.T) {
 
 	p1 := cfg.Processors["attributes/2"]
 	assert.Equal(t, p1,
-		&ConfigV2{
+		&Config{
 			ProcessorSettings: configmodels.ProcessorSettings{
 				TypeVal: "attributes",
 				NameVal: "attributes/2",

--- a/processor/addattributesprocessor/factory.go
+++ b/processor/addattributesprocessor/factory.go
@@ -41,7 +41,7 @@ func (f *factory) Type() string {
 
 // CreateDefaultConfig creates the default configuration for processor.
 func (f *factory) CreateDefaultConfig() configmodels.Processor {
-	return &ConfigV2{
+	return &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			TypeVal: typeStr,
 			NameVal: typeStr,
@@ -56,7 +56,7 @@ func (f *factory) CreateTraceProcessor(
 	nextConsumer consumer.TraceConsumer,
 	cfg configmodels.Processor,
 ) (processor.TraceProcessor, error) {
-	oCfg := cfg.(*ConfigV2)
+	oCfg := cfg.(*Config)
 	return NewTraceProcessor(nextConsumer, WithAttributes(oCfg.Values), WithOverwrite(oCfg.Overwrite))
 }
 

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -18,29 +18,29 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
 )
 
-// ConfigV2 defines configuration for Jaeger receiver.
-type ConfigV2 struct {
+// Config defines configuration for Jaeger receiver.
+type Config struct {
 	TypeVal   string                                    `mapstructure:"-"`
 	NameVal   string                                    `mapstructure:"-"`
 	Protocols map[string]*configmodels.ReceiverSettings `mapstructure:"protocols"`
 }
 
 // Name gets the receiver name.
-func (rs *ConfigV2) Name() string {
+func (rs *Config) Name() string {
 	return rs.NameVal
 }
 
 // SetName sets the receiver name.
-func (rs *ConfigV2) SetName(name string) {
+func (rs *Config) SetName(name string) {
 	rs.NameVal = name
 }
 
 // Type sets the receiver type.
-func (rs *ConfigV2) Type() string {
+func (rs *Config) Type() string {
 	return rs.TypeVal
 }
 
 // SetType sets the receiver type.
-func (rs *ConfigV2) SetType(typeStr string) {
+func (rs *Config) SetType(typeStr string) {
 	rs.TypeVal = typeStr
 }

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -41,9 +41,9 @@ func TestLoadConfig(t *testing.T) {
 	r0 := cfg.Receivers["jaeger"]
 	assert.Equal(t, r0, factory.CreateDefaultConfig())
 
-	r1 := cfg.Receivers["jaeger/customname"].(*ConfigV2)
+	r1 := cfg.Receivers["jaeger/customname"].(*Config)
 	assert.Equal(t, r1,
-		&ConfigV2{
+		&Config{
 			TypeVal: typeStr,
 			NameVal: "jaeger/customname",
 			Protocols: map[string]*configmodels.ReceiverSettings{

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -62,7 +62,7 @@ func (f *factory) CustomUnmarshaler() receiver.CustomUnmarshaler {
 
 // CreateDefaultConfig creates the default configuration for Jaeger receiver.
 func (f *factory) CreateDefaultConfig() configmodels.Receiver {
-	return &ConfigV2{
+	return &Config{
 		TypeVal: typeStr,
 		NameVal: typeStr,
 		Protocols: map[string]*configmodels.ReceiverSettings{
@@ -89,7 +89,7 @@ func (f *factory) CreateTraceReceiver(
 	// Convert settings in the source config to Configuration struct
 	// that Jaeger receiver understands.
 
-	rCfg := cfg.(*ConfigV2)
+	rCfg := cfg.(*Config)
 
 	protoHTTP := rCfg.Protocols[protoThriftHTTP]
 	protoTChannel := rCfg.Protocols[protoThriftTChannel]

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -47,7 +47,7 @@ func TestCreateReceiver(t *testing.T) {
 func TestCreateNoEndpoints(t *testing.T) {
 	factory := receiver.GetFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
-	rCfg := cfg.(*ConfigV2)
+	rCfg := cfg.(*Config)
 
 	rCfg.Protocols[protoThriftHTTP].Endpoint = ""
 	rCfg.Protocols[protoThriftTChannel].Endpoint = ""
@@ -58,7 +58,7 @@ func TestCreateNoEndpoints(t *testing.T) {
 func TestCreateInvalidTChannelEndpoint(t *testing.T) {
 	factory := receiver.GetFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
-	rCfg := cfg.(*ConfigV2)
+	rCfg := cfg.(*Config)
 
 	rCfg.Protocols[protoThriftTChannel].Endpoint = ""
 	_, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
@@ -68,7 +68,7 @@ func TestCreateInvalidTChannelEndpoint(t *testing.T) {
 func TestCreateNoPort(t *testing.T) {
 	factory := receiver.GetFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
-	rCfg := cfg.(*ConfigV2)
+	rCfg := cfg.(*Config)
 
 	rCfg.Protocols[protoThriftHTTP].Endpoint = "127.0.0.1:"
 	_, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
@@ -78,7 +78,7 @@ func TestCreateNoPort(t *testing.T) {
 func TestCreateLargePort(t *testing.T) {
 	factory := receiver.GetFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
-	rCfg := cfg.(*ConfigV2)
+	rCfg := cfg.(*Config)
 
 	rCfg.Protocols[protoThriftHTTP].Endpoint = "127.0.0.1:65536"
 	_, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
@@ -88,7 +88,7 @@ func TestCreateLargePort(t *testing.T) {
 func TestCreateNoProtocols(t *testing.T) {
 	factory := receiver.GetFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
-	rCfg := cfg.(*ConfigV2)
+	rCfg := cfg.(*Config)
 
 	delete(rCfg.Protocols, protoThriftHTTP)
 	delete(rCfg.Protocols, protoThriftTChannel)

--- a/receiver/opencensusreceiver/config.go
+++ b/receiver/opencensusreceiver/config.go
@@ -16,7 +16,7 @@ package opencensusreceiver
 
 import "github.com/open-telemetry/opentelemetry-service/config/configmodels"
 
-// ConfigV2 defines configuration for OpenCensus receiver.
-type ConfigV2 struct {
+// Config defines configuration for OpenCensus receiver.
+type Config struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 }

--- a/receiver/opencensusreceiver/config_test.go
+++ b/receiver/opencensusreceiver/config_test.go
@@ -42,7 +42,7 @@ func TestLoadConfig(t *testing.T) {
 	r0 := cfg.Receivers["opencensus"]
 	assert.Equal(t, r0, factory.CreateDefaultConfig())
 
-	r1 := cfg.Receivers["opencensus/customname"].(*ConfigV2)
+	r1 := cfg.Receivers["opencensus/customname"].(*Config)
 	assert.Equal(t, r1.ReceiverSettings,
 		configmodels.ReceiverSettings{
 			TypeVal:  typeStr,

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -48,7 +48,7 @@ func (f *factory) CustomUnmarshaler() receiver.CustomUnmarshaler {
 
 // CreateDefaultConfig creates the default configuration for receiver.
 func (f *factory) CreateDefaultConfig() configmodels.Receiver {
-	return &ConfigV2{
+	return &Config{
 		ReceiverSettings: configmodels.ReceiverSettings{
 			TypeVal:  typeStr,
 			NameVal:  typeStr,
@@ -94,7 +94,7 @@ func (f *factory) CreateMetricsReceiver(
 }
 
 func (f *factory) createReceiver(cfg configmodels.Receiver) (*Receiver, error) {
-	rCfg := cfg.(*ConfigV2)
+	rCfg := cfg.(*Config)
 
 	// There must be one receiver for both metrics and traces. We maintain a map of
 	// receivers per config.
@@ -118,4 +118,4 @@ func (f *factory) createReceiver(cfg configmodels.Receiver) (*Receiver, error) {
 // We maintain this map because the factory is asked trace and metric receivers separately
 // when it gets CreateTraceReceiver() and CreateMetricsReceiver() but they must not
 // create separate objects, they must use one Receiver object per configuration.
-var receivers = map[*ConfigV2]*Receiver{}
+var receivers = map[*Config]*Receiver{}

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -36,7 +36,7 @@ func TestCreateReceiver(t *testing.T) {
 	factory := receiver.GetFactory(typeStr)
 	cfg := factory.CreateDefaultConfig()
 
-	config := cfg.(*ConfigV2)
+	config := cfg.(*Config)
 	config.Endpoint = testutils.GetAvailableLocalAddress(t)
 
 	tReceiver, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -22,8 +22,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
 )
 
-// ConfigV2 defines configuration for Prometheus receiver.
-type ConfigV2 struct {
+// Config defines configuration for Prometheus receiver.
+type Config struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"`
 	PrometheusConfig              *config.Config `mapstructure:"-"`
 	BufferPeriod                  time.Duration  `mapstructure:"buffer_period"`

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -42,7 +42,7 @@ func TestLoadConfig(t *testing.T) {
 	r0 := cfg.Receivers["prometheus"]
 	assert.Equal(t, r0, factory.CreateDefaultConfig())
 
-	r1 := cfg.Receivers["prometheus/customname"].(*ConfigV2)
+	r1 := cfg.Receivers["prometheus/customname"].(*Config)
 	assert.Equal(t, r1.ReceiverSettings,
 		configmodels.ReceiverSettings{
 			TypeVal:  typeStr,

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -73,7 +73,7 @@ func CustomUnmarshalerFunc(v *viper.Viper, viperKey string, intoCfg interface{})
 		return fmt.Errorf("prometheus receiver failed to marshal config to yaml: %s", err)
 	}
 
-	config := intoCfg.(*ConfigV2)
+	config := intoCfg.(*Config)
 
 	err = yaml.Unmarshal(out, &config.PrometheusConfig)
 	if err != nil {
@@ -87,7 +87,7 @@ func CustomUnmarshalerFunc(v *viper.Viper, viperKey string, intoCfg interface{})
 
 // CreateDefaultConfig creates the default configuration for receiver.
 func (f *factory) CreateDefaultConfig() configmodels.Receiver {
-	return &ConfigV2{
+	return &Config{
 		ReceiverSettings: configmodels.ReceiverSettings{
 			TypeVal:  typeStr,
 			NameVal:  typeStr,
@@ -114,7 +114,7 @@ func (f *factory) CreateMetricsReceiver(
 	consumer consumer.MetricsConsumer,
 ) (receiver.MetricsReceiver, error) {
 
-	rCfg := cfg.(*ConfigV2)
+	rCfg := cfg.(*Config)
 
 	// Create receiver Configuration from our input cfg
 	config := Configuration{

--- a/receiver/vmmetricsreceiver/config.go
+++ b/receiver/vmmetricsreceiver/config.go
@@ -20,8 +20,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
 )
 
-// ConfigV2 defines configuration for VMMetrics receiver.
-type ConfigV2 struct {
+// Config defines configuration for VMMetrics receiver.
+type Config struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"`
 	ScrapeInterval                time.Duration `mapstructure:"scrape_interval"`
 	MountPoint                    string        `mapstructure:"mount_point"`

--- a/receiver/vmmetricsreceiver/config_test.go
+++ b/receiver/vmmetricsreceiver/config_test.go
@@ -42,9 +42,9 @@ func TestLoadConfig(t *testing.T) {
 	r0 := cfg.Receivers["vmmetrics"]
 	assert.Equal(t, r0, factory.CreateDefaultConfig())
 
-	r1 := cfg.Receivers["vmmetrics/customname"].(*ConfigV2)
+	r1 := cfg.Receivers["vmmetrics/customname"].(*Config)
 	assert.Equal(t, r1,
-		&ConfigV2{
+		&Config{
 			ReceiverSettings: configmodels.ReceiverSettings{
 				TypeVal: typeStr,
 				NameVal: "vmmetrics/customname",

--- a/receiver/vmmetricsreceiver/factory.go
+++ b/receiver/vmmetricsreceiver/factory.go
@@ -52,7 +52,7 @@ func (f *factory) CustomUnmarshaler() receiver.CustomUnmarshaler {
 
 // CreateDefaultConfig creates the default configuration for receiver.
 func (f *factory) CreateDefaultConfig() configmodels.Receiver {
-	return &ConfigV2{
+	return &Config{
 		ReceiverSettings: configmodels.ReceiverSettings{
 			TypeVal: typeStr,
 			NameVal: typeStr,
@@ -81,7 +81,7 @@ func (f *factory) CreateMetricsReceiver(
 	if runtime.GOOS != "linux" {
 		return nil, errors.New("vmmetrics receiver is only supported on linux")
 	}
-	cfg := config.(*ConfigV2)
+	cfg := config.(*Config)
 
 	vmc, err := NewVMMetricsCollector(cfg.ScrapeInterval, cfg.MountPoint, cfg.ProcessMountPoint, cfg.MetricPrefix, consumer)
 	if err != nil {

--- a/receiver/zipkinreceiver/config.go
+++ b/receiver/zipkinreceiver/config.go
@@ -16,7 +16,7 @@ package zipkinreceiver
 
 import "github.com/open-telemetry/opentelemetry-service/config/configmodels"
 
-// ConfigV2 defines configuration for Zipkin receiver.
-type ConfigV2 struct {
+// Config defines configuration for Zipkin receiver.
+type Config struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"`
 }

--- a/receiver/zipkinreceiver/config_test.go
+++ b/receiver/zipkinreceiver/config_test.go
@@ -41,9 +41,9 @@ func TestLoadConfig(t *testing.T) {
 	r0 := cfg.Receivers["zipkin"]
 	assert.Equal(t, r0, factory.CreateDefaultConfig())
 
-	r1 := cfg.Receivers["zipkin/customname"].(*ConfigV2)
+	r1 := cfg.Receivers["zipkin/customname"].(*Config)
 	assert.Equal(t, r1,
-		&ConfigV2{
+		&Config{
 			ReceiverSettings: configmodels.ReceiverSettings{
 				TypeVal:  typeStr,
 				NameVal:  "zipkin/customname",

--- a/receiver/zipkinreceiver/factory.go
+++ b/receiver/zipkinreceiver/factory.go
@@ -52,7 +52,7 @@ func (f *factory) CustomUnmarshaler() receiver.CustomUnmarshaler {
 
 // CreateDefaultConfig creates the default configuration for Jaeger receiver.
 func (f *factory) CreateDefaultConfig() configmodels.Receiver {
-	return &ConfigV2{
+	return &Config{
 		ReceiverSettings: configmodels.ReceiverSettings{
 			TypeVal:  typeStr,
 			NameVal:  typeStr,
@@ -69,7 +69,7 @@ func (f *factory) CreateTraceReceiver(
 	nextConsumer consumer.TraceConsumer,
 ) (receiver.TraceReceiver, error) {
 
-	rCfg := cfg.(*ConfigV2)
+	rCfg := cfg.(*Config)
 	return New(rCfg.Endpoint, nextConsumer)
 }
 


### PR DESCRIPTION
The old config format is no longer needed and as planned
we are renaming ConfigV2 to be simply "Config".