### PR TITLE
Clean up stale code in receiver/vmmetrics

### DIFF
--- a/receiver/vmmetricsreceiver/.nocover
+++ b/receiver/vmmetricsreceiver/.nocover
@@ -1,1 +1,0 @@
-FIXME: This will get re-written and moved.

--- a/receiver/vmmetricsreceiver/factory.go
+++ b/receiver/vmmetricsreceiver/factory.go
@@ -77,6 +77,7 @@ func (f *Factory) CreateMetricsReceiver(
 ) (receiver.MetricsReceiver, error) {
 
 	if runtime.GOOS != "linux" {
+		// TODO: add support for other platforms.
 		return nil, errors.New("vmmetrics receiver is only supported on linux")
 	}
 	cfg := config.(*Config)

--- a/receiver/vmmetricsreceiver/metrics_receiver.go
+++ b/receiver/vmmetricsreceiver/metrics_receiver.go
@@ -16,14 +16,8 @@ package vmmetricsreceiver
 
 import (
 	"errors"
-	"fmt"
-	"runtime"
 	"sync"
-	"time"
 
-	"github.com/spf13/viper"
-
-	"github.com/open-telemetry/opentelemetry-service/consumer"
 	"github.com/open-telemetry/opentelemetry-service/receiver"
 )
 
@@ -33,14 +27,6 @@ var (
 	errNilMetricsConsumer = errors.New("expecting a non-nil MetricsConsumer")
 )
 
-// Configuration defines the behavior and targets of the VM metrics scrapers.
-type Configuration struct {
-	scrapeInterval    time.Duration `mapstructure:"scrape_interval"`
-	mountPoint        string        `mapstructure:"mount_point"`
-	processMountPoint string        `mapstructure:"process_mount_point"`
-	metricPrefix      string        `mapstructure:"metric_prefix"`
-}
-
 // Receiver is the type used to handle metrics from VM metrics.
 type Receiver struct {
 	mu sync.Mutex
@@ -49,31 +35,6 @@ type Receiver struct {
 
 	stopOnce  sync.Once
 	startOnce sync.Once
-}
-
-// New creates a new vmmetricsreceiver.Receiver reference.
-func New(v *viper.Viper, consumer consumer.MetricsConsumer) (*Receiver, error) {
-	if consumer == nil {
-		return nil, errNilMetricsConsumer
-	}
-
-	var cfg Configuration
-
-	// Unmarshal our config values (using viper's mapstructure)
-	err := unmarshal(&cfg, v.AllSettings())
-	if err != nil {
-		return nil, fmt.Errorf("vmmetrics receiver failed to parse config: %s", err)
-	}
-
-	vmc, err := NewVMMetricsCollector(cfg.scrapeInterval, cfg.mountPoint, cfg.processMountPoint, cfg.metricPrefix, consumer)
-	if err != nil {
-		return nil, err
-	}
-
-	vmr := &Receiver{
-		vmc: vmc,
-	}
-	return vmr, nil
 }
 
 const metricsSource string = "VMMetrics"
@@ -90,14 +51,7 @@ func (vmr *Receiver) StartMetricsReception(host receiver.Host) error {
 
 	var err = errAlreadyStarted
 	vmr.startOnce.Do(func() {
-		switch runtime.GOOS {
-		case "linux":
-			vmr.vmc.StartCollection()
-		case "darwin", "freebsd", "windows":
-			// TODO: add support for other platforms.
-			return
-		}
-
+		vmr.vmc.StartCollection()
 		err = nil
 	})
 	return err
@@ -114,22 +68,4 @@ func (vmr *Receiver) StopMetricsReception() error {
 		err = nil
 	})
 	return err
-}
-
-// TODO(songya): investigate why viper.Unmarshal didn't work, remove this method and use viper.Unmarshal instead.
-func unmarshal(cfg *Configuration, settings map[string]interface{}) error {
-	if interval, ok := settings["scrape_interval"]; ok {
-		intervalInSecs := interval.(int)
-		cfg.scrapeInterval = time.Duration(intervalInSecs * int(time.Second))
-	}
-	if mountPoint, ok := settings["mount_point"]; ok {
-		cfg.mountPoint = mountPoint.(string)
-	}
-	if processMountPoint, ok := settings["process_mount_point"]; ok {
-		cfg.processMountPoint = processMountPoint.(string)
-	}
-	if prefix, ok := settings["metric_prefix"]; ok {
-		cfg.metricPrefix = prefix.(string)
-	}
-	return nil
 }


### PR DESCRIPTION
Receiver will be loaded through config.go instead of viper.