### PR TITLE
Update attributekeyprocessor to current factory registration

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/internal/collector/processor/queued"
 	"github.com/open-telemetry/opentelemetry-service/processor"
 	"github.com/open-telemetry/opentelemetry-service/processor/addattributesprocessor"
+	"github.com/open-telemetry/opentelemetry-service/processor/attributekeyprocessor"
 	"github.com/open-telemetry/opentelemetry-service/receiver"
 	"github.com/open-telemetry/opentelemetry-service/receiver/jaegerreceiver"
 	"github.com/open-telemetry/opentelemetry-service/receiver/opencensusreceiver"
@@ -64,6 +65,7 @@ func Components() (
 
 	processors, err := processor.Build(
 		&addattributesprocessor.Factory{},
+		&attributekeyprocessor.Factory{},
 		&queued.Factory{},
 		&nodebatcher.Factory{},
 	)

--- a/defaults/defaults_test.go
+++ b/defaults/defaults_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/internal/collector/processor/queued"
 	"github.com/open-telemetry/opentelemetry-service/processor"
 	"github.com/open-telemetry/opentelemetry-service/processor/addattributesprocessor"
+	"github.com/open-telemetry/opentelemetry-service/processor/attributekeyprocessor"
 	"github.com/open-telemetry/opentelemetry-service/receiver"
 	"github.com/open-telemetry/opentelemetry-service/receiver/jaegerreceiver"
 	"github.com/open-telemetry/opentelemetry-service/receiver/opencensusreceiver"
@@ -47,9 +48,10 @@ func TestDefaultComponents(t *testing.T) {
 		"vmmetrics":  &vmmetricsreceiver.Factory{},
 	}
 	expectedProcessors := map[string]processor.Factory{
-		"attributes":   &addattributesprocessor.Factory{},
-		"queued-retry": &queued.Factory{},
-		"batch":        &nodebatcher.Factory{},
+		"attributes":    &addattributesprocessor.Factory{},
+		"attribute-key": &attributekeyprocessor.Factory{},
+		"queued-retry":  &queued.Factory{},
+		"batch":         &nodebatcher.Factory{},
 	}
 	expectedExporters := map[string]exporter.Factory{
 		"opencensus": &opencensusexporter.Factory{},

--- a/processor/attributekeyprocessor/config_test.go
+++ b/processor/attributekeyprocessor/config_test.go
@@ -26,11 +26,18 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/processor"
 )
 
-var _ = config.RegisterTestFactories()
-
 func TestLoadConfig(t *testing.T) {
+	receivers, _, exporters, err := config.ExampleComponents()
+	processors, err := processor.Build(&Factory{})
+	require.NotNil(t, processors)
+	require.NoError(t, err)
 
-	config, err := config.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"))
+	config, err := config.LoadConfigFile(
+		t,
+		path.Join(".", "testdata", "config.yaml"),
+		receivers,
+		processors,
+		exporters)
 
 	require.Nil(t, err)
 	require.NotNil(t, config)
@@ -68,12 +75,21 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestLoadConfigEmpty(t *testing.T) {
-	factory := processor.GetFactory(typeStr)
+	receivers, _, exporters, err := config.ExampleComponents()
+	processors, err := processor.Build(&Factory{})
+	require.NotNil(t, processors)
+	require.NoError(t, err)
 
-	config, err := config.LoadConfigFile(t, path.Join(".", "testdata", "empty.yaml"))
+	config, err := config.LoadConfigFile(
+		t,
+		path.Join(".", "testdata", "empty.yaml"),
+		receivers,
+		processors,
+		exporters)
 
 	require.Nil(t, err)
 	require.NotNil(t, config)
 	p0 := config.Processors["attribute-key"]
+	factory := &Factory{}
 	assert.Equal(t, p0, factory.CreateDefaultConfig())
 }

--- a/processor/attributekeyprocessor/factory.go
+++ b/processor/attributekeyprocessor/factory.go
@@ -23,24 +23,22 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/processor"
 )
 
-var _ = processor.RegisterFactory(&factory{})
-
 const (
 	// The value of "type" Attribute Key in configuration.
 	typeStr = "attribute-key"
 )
 
-// factory is the factory for Attribute Key processor.
-type factory struct {
+// Factory is the factory for Attribute Key processor.
+type Factory struct {
 }
 
 // Type gets the type of the config created by this factory.
-func (f *factory) Type() string {
+func (f *Factory) Type() string {
 	return typeStr
 }
 
 // CreateDefaultConfig creates the default configuration for processor.
-func (f *factory) CreateDefaultConfig() configmodels.Processor {
+func (f *Factory) CreateDefaultConfig() configmodels.Processor {
 	return &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			TypeVal: typeStr,
@@ -51,7 +49,7 @@ func (f *factory) CreateDefaultConfig() configmodels.Processor {
 }
 
 // CreateTraceProcessor creates a trace processor based on this config.
-func (f *factory) CreateTraceProcessor(
+func (f *Factory) CreateTraceProcessor(
 	logger *zap.Logger,
 	nextConsumer consumer.TraceConsumer,
 	cfg configmodels.Processor,
@@ -61,7 +59,7 @@ func (f *factory) CreateTraceProcessor(
 }
 
 // CreateMetricsProcessor creates a metrics processor based on this config.
-func (f *factory) CreateMetricsProcessor(
+func (f *Factory) CreateMetricsProcessor(
 	logger *zap.Logger,
 	nextConsumer consumer.MetricsConsumer,
 	cfg configmodels.Processor,

--- a/processor/attributekeyprocessor/factory_test.go
+++ b/processor/attributekeyprocessor/factory_test.go
@@ -23,11 +23,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
-	"github.com/open-telemetry/opentelemetry-service/processor"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
-	factory := processor.GetFactory(typeStr)
+	factory := &Factory{}
 	require.NotNil(t, factory)
 
 	cfg := factory.CreateDefaultConfig()
@@ -35,7 +34,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 }
 
 func TestCreateProcessor(t *testing.T) {
-	factory := processor.GetFactory(typeStr)
+	factory := &Factory{}
 	require.NotNil(t, factory)
 
 	cfg := factory.CreateDefaultConfig()


### PR DESCRIPTION
The original PR was made before the change in model of factory registration. This change moves it to the current factory registration.