### PR TITLE
Add OC receiver config settings

### DIFF
--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -99,9 +99,14 @@ func (f *Factory) createReceiver(cfg configmodels.Receiver) (*Receiver, error) {
 	// Check to see if there is already a receiver for this config.
 	receiver, ok := receivers[rCfg]
 	if !ok {
+		// Build the configuration options.
+		opts, err := rCfg.buildOptions()
+		if err != nil {
+			return nil, err
+		}
+
 		// We don't have a receiver, so create one.
-		var err error
-		receiver, err = New(rCfg.Endpoint, nil, nil)
+		receiver, err = New(rCfg.Endpoint, nil, nil, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -17,12 +17,16 @@ package opencensusreceiver
 import (
 	"context"
 	"testing"
-
-	"go.uber.org/zap"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-service/internal/testutils"
+	"github.com/open-telemetry/opentelemetry-service/receiver"
+	"github.com/open-telemetry/opentelemetry-service/receiver/receivertest"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -42,9 +46,139 @@ func TestCreateReceiver(t *testing.T) {
 	assert.NotNil(t, tReceiver)
 	assert.Nil(t, err)
 
-	// The default config does not provide scrape_config so we expect that metrics receiver
-	// creation must also fail.
 	mReceiver, err := factory.CreateMetricsReceiver(zap.NewNop(), cfg, nil)
 	assert.NotNil(t, mReceiver)
 	assert.Nil(t, err)
+}
+
+func TestCreateTraceReceiver(t *testing.T) {
+	factory := receiver.GetFactory(typeStr)
+	endpoint := testutils.GetAvailableLocalAddress(t)
+	defaultReceiverSettings := configmodels.ReceiverSettings{
+		TypeVal:  typeStr,
+		NameVal:  typeStr,
+		Endpoint: endpoint,
+		Enabled:  true,
+	}
+	tests := []struct {
+		name    string
+		cfg     *Config
+		wantErr bool
+	}{
+		{
+			name: "default",
+			cfg: &Config{
+				ReceiverSettings: defaultReceiverSettings,
+			},
+		},
+		{
+			name: "invalid_port",
+			cfg: &Config{
+				ReceiverSettings: configmodels.ReceiverSettings{
+					TypeVal:  typeStr,
+					NameVal:  typeStr,
+					Endpoint: "127.0.0.1:112233",
+					Enabled:  true,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "max-msg-size-and-concurrent-connections",
+			cfg: &Config{
+				ReceiverSettings:     defaultReceiverSettings,
+				MaxRecvMsgSizeMiB:    32,
+				MaxConcurrentStreams: 16,
+			},
+		},
+	}
+	ctx := context.Background()
+	logger := zap.NewNop()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sink := new(exportertest.SinkTraceExporter)
+			tr, err := factory.CreateTraceReceiver(ctx, logger, tt.cfg, sink)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("factory.CreateTraceReceiver() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tr != nil {
+				mh := receivertest.NewMockHost()
+				if err := tr.StartTraceReception(mh); err == nil {
+					tr.StopTraceReception()
+				} else {
+					t.Fatalf("StartTraceReception() error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateMetricReceiver(t *testing.T) {
+	factory := receiver.GetFactory(typeStr)
+	endpoint := testutils.GetAvailableLocalAddress(t)
+	defaultReceiverSettings := configmodels.ReceiverSettings{
+		TypeVal:  typeStr,
+		NameVal:  typeStr,
+		Endpoint: endpoint,
+		Enabled:  true,
+	}
+	tests := []struct {
+		name    string
+		cfg     *Config
+		wantErr bool
+	}{
+		{
+			name: "default",
+			cfg: &Config{
+				ReceiverSettings: defaultReceiverSettings,
+			},
+		},
+		{
+			name: "invalid_address",
+			cfg: &Config{
+				ReceiverSettings: configmodels.ReceiverSettings{
+					TypeVal:  typeStr,
+					NameVal:  typeStr,
+					Endpoint: "327.0.0.1:1122",
+					Enabled:  true,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "keepalive",
+			cfg: &Config{
+				ReceiverSettings: defaultReceiverSettings,
+				Keepalive: &serverParametersAndEnforcementPolicy{
+					ServerParameters: &keepaliveServerParameters{
+						MaxConnectionAge: 60 * time.Second,
+					},
+					EnforcementPolicy: &keepaliveEnforcementPolicy{
+						MinTime:             30 * time.Second,
+						PermitWithoutStream: true,
+					},
+				},
+			},
+		},
+	}
+	logger := zap.NewNop()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sink := new(exportertest.SinkMetricsExporter)
+			tc, err := factory.CreateMetricsReceiver(logger, tt.cfg, sink)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("factory.CreateMetricsReceiver() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tc != nil {
+				mh := receivertest.NewMockHost()
+				if err := tc.StartMetricsReception(mh); err == nil {
+					tc.StopMetricsReception()
+				} else {
+					t.Fatalf("StartTraceReception() error = %v", err)
+				}
+			}
+		})
+	}
 }

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-service/internal/testutils"
-	"github.com/open-telemetry/opentelemetry-service/receiver"
 	"github.com/open-telemetry/opentelemetry-service/receiver/receivertest"
 )
 
@@ -52,7 +51,7 @@ func TestCreateReceiver(t *testing.T) {
 }
 
 func TestCreateTraceReceiver(t *testing.T) {
-	factory := receiver.GetFactory(typeStr)
+	factory := Factory{}
 	endpoint := testutils.GetAvailableLocalAddress(t)
 	defaultReceiverSettings := configmodels.ReceiverSettings{
 		TypeVal:  typeStr,
@@ -115,7 +114,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 }
 
 func TestCreateMetricReceiver(t *testing.T) {
-	factory := receiver.GetFactory(typeStr)
+	factory := Factory{}
 	endpoint := testutils.GetAvailableLocalAddress(t)
 	defaultReceiverSettings := configmodels.ReceiverSettings{
 		TypeVal:  typeStr,

--- a/receiver/opencensusreceiver/opencensus.go
+++ b/receiver/opencensusreceiver/opencensus.go
@@ -100,15 +100,10 @@ func (ocr *Receiver) TraceSource() string {
 	return source
 }
 
-// StartTraceReception exclusively runs the Trace receiver on the gRPC server.
-// To start both Trace and Metrics receivers/services, please use Start.
+// StartTraceReception runs the trace receiver on the gRPC server. Currently
+// it also enables the metrics receiver too.
 func (ocr *Receiver) StartTraceReception(host receiver.Host) error {
-	err := ocr.registerTraceConsumer()
-	if err != nil && err != errAlreadyStarted {
-		return err
-	}
-	// TODO: (@pjanotti) pass asyncErrorChan down the chain
-	return ocr.startServer()
+	return ocr.start()
 }
 
 func (ocr *Receiver) registerTraceConsumer() error {
@@ -130,14 +125,10 @@ func (ocr *Receiver) MetricsSource() string {
 	return source
 }
 
-// StartMetricsReception exclusively runs the Metrics receiver on the gRPC server.
-// To start both Trace and Metrics receivers/services, please use Start.
+// StartMetricsReception runs the metrics receiver on the gRPC server. Currently
+// it also enables the trace receiver too.
 func (ocr *Receiver) StartMetricsReception(host receiver.Host) error {
-	err := ocr.registerMetricsConsumer()
-	if err != nil && err != errAlreadyStarted {
-		return err
-	}
-	return ocr.startServer()
+	return ocr.start()
 }
 
 func (ocr *Receiver) registerMetricsConsumer() error {
@@ -164,34 +155,47 @@ func (ocr *Receiver) grpcServer() *grpc.Server {
 	return ocr.serverGRPC
 }
 
-// StopTraceReception is a method to turn off receiving traces. It
-// currently is a noop because we don't yet know if gRPC allows
-// stopping a specific service.
+// StopTraceReception is a method to turn off receiving traces. It stops
+// metrics reception too.
 func (ocr *Receiver) StopTraceReception() error {
-	// StopTraceReception is a noop currently.
 	// TODO: (@odeke-em) investigate whether or not gRPC
 	// provides a way to stop specific services.
-	ocr.traceReceiver.Stop()
-	return nil
-}
-
-// StopMetricsReception is a method to turn off receiving metrics. It
-// currently is a noop because we don't yet know if gRPC allows
-// stopping a specific service.
-func (ocr *Receiver) StopMetricsReception() error {
-	// StopMetricsReception is a noop currently.
-	// TODO: (@odeke-em) investigate whether or not gRPC
-	// provides a way to stop specific services.
-	return nil
-}
-
-// Start runs all the receivers/services namely, Trace and Metrics services.
-func (ocr *Receiver) Start(ctx context.Context) error {
-	if err := ocr.registerTraceConsumer(); err != nil && err != errAlreadyStarted {
+	if err := ocr.stop(); err != errAlreadyStopped {
 		return err
 	}
-	if err := ocr.registerMetricsConsumer(); err != nil && err != errAlreadyStarted {
+	return nil
+}
+
+// StopMetricsReception is a method to turn off receiving metrics. It stops
+// trace reception too.
+func (ocr *Receiver) StopMetricsReception() error {
+	// TODO: (@odeke-em) investigate whether or not gRPC
+	// provides a way to stop specific services.
+	if err := ocr.stop(); err != errAlreadyStopped {
 		return err
+	}
+	return nil
+}
+
+// start runs all the receivers/services namely, Trace and Metrics services.
+func (ocr *Receiver) start() error {
+	hasConsumer := false
+	if ocr.traceConsumer != nil {
+		hasConsumer = true
+		if err := ocr.registerTraceConsumer(); err != nil && err != errAlreadyStarted {
+			return err
+		}
+	}
+
+	if ocr.metricsConsumer != nil {
+		hasConsumer = true
+		if err := ocr.registerMetricsConsumer(); err != nil && err != errAlreadyStarted {
+			return err
+		}
+	}
+
+	if !hasConsumer {
+		return errors.New("cannot start receiver: no consumers were specified")
 	}
 
 	if err := ocr.startServer(); err != nil && err != errAlreadyStarted {
@@ -203,13 +207,21 @@ func (ocr *Receiver) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop stops the underlying gRPC server and all the services running on it.
-func (ocr *Receiver) Stop() error {
+// stop stops the underlying gRPC server and all the services running on it.
+func (ocr *Receiver) stop() error {
 	ocr.mu.Lock()
 	defer ocr.mu.Unlock()
 
 	var err = errAlreadyStopped
 	ocr.stopOnce.Do(func() {
+		err = nil
+
+		if ocr.traceReceiver != nil {
+			ocr.traceReceiver.Stop()
+		}
+
+		// Currently there is no symmetric stop for metrics receiver.
+
 		if ocr.serverHTTP != nil {
 			_ = ocr.serverHTTP.Close()
 		}

--- a/receiver/opencensusreceiver/opencensus.go
+++ b/receiver/opencensusreceiver/opencensus.go
@@ -158,8 +158,6 @@ func (ocr *Receiver) grpcServer() *grpc.Server {
 // StopTraceReception is a method to turn off receiving traces. It stops
 // metrics reception too.
 func (ocr *Receiver) StopTraceReception() error {
-	// TODO: (@odeke-em) investigate whether or not gRPC
-	// provides a way to stop specific services.
 	if err := ocr.stop(); err != errAlreadyStopped {
 		return err
 	}
@@ -169,8 +167,6 @@ func (ocr *Receiver) StopTraceReception() error {
 // StopMetricsReception is a method to turn off receiving metrics. It stops
 // trace reception too.
 func (ocr *Receiver) StopMetricsReception() error {
-	// TODO: (@odeke-em) investigate whether or not gRPC
-	// provides a way to stop specific services.
 	if err := ocr.stop(); err != errAlreadyStopped {
 		return err
 	}

--- a/receiver/opencensusreceiver/testdata/config.yaml
+++ b/receiver/opencensusreceiver/testdata/config.yaml
@@ -2,6 +2,18 @@ receivers:
   opencensus:
   opencensus/customname:
     endpoint: 0.0.0.0:9090
+  opencensus/keepalive:
+    keepalive:
+      server-parameters:
+        time: 30s
+        timeout: 5s
+      enforcement-policy:
+        min-time: 10s
+        permit-without-stream: true
+  opencensus/nobackpressure:
+    disable-backpressure: true
+    max-recv-msg-size-mib: 32
+    max-concurrent-streams: 16
 
 processors:
   exampleprocessor:

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -198,6 +198,7 @@ github.com/opentracing-contrib/go-stdlib v0.0.0-20170113013457-1de4cc2120e7/go.m
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.1 h1:IYN/cK5AaULfeMAlgFZSIBLSpsZ5MRHDy1fKBEqqJfQ=
 github.com/opentracing/opentracing-go v1.0.1/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/orijtech/prometheus-go-metrics-exporter v0.0.3-0.20190313163149-b321c5297f60 h1:vN7d/Zv6aOXqhspiqoEMkb6uFHNARVESmYn5XtNeyrk=
@@ -282,6 +283,7 @@ github.com/uber-go/atomic v1.4.0 h1:yOuPqEq4ovnhEjpHmfFwsqBXDYbQeT6Nb0bwD6XnD5o=
 github.com/uber-go/atomic v1.4.0/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
 github.com/uber/jaeger-client-go v2.15.0+incompatible h1:NP3qsSqNxh8VYr956ur1N/1C1PjvOJnJykCzcD5QHbk=
 github.com/uber/jaeger-client-go v2.15.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
+github.com/uber/jaeger-client-go v2.16.0+incompatible h1:Q2Pp6v3QYiocMxomCaJuwQGFt7E53bPYqEgug/AoBtY=
 github.com/uber/jaeger-client-go v2.16.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.0.0+incompatible h1:iMSCV0rmXEogjNWPh2D0xk9YVKvrtGoHJNe9ebLu/pw=
 github.com/uber/jaeger-lib v2.0.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -104,7 +104,7 @@ func (mb *MockBackend) Start(backendType BackendType) error {
 			return err
 		}
 
-		err := mb.ocReceiver.Start(context.Background())
+		err := mb.ocReceiver.StartTraceReception(mb)
 		if err != nil {
 			return err
 		}
@@ -149,7 +149,7 @@ func (mb *MockBackend) Stop() {
 		mb.logFile.Close()
 
 		if mb.ocReceiver != nil {
-			_ = mb.ocReceiver.Stop()
+			_ = mb.ocReceiver.StopTraceReception()
 		}
 
 		if mb.jaegerReceiver != nil {


### PR DESCRIPTION
Add OC receiver config settings in the new format. This brings the settings that were available in the old format to the new config format. No new settings were added or handled at this point.