### PR TITLE
receiver/opencensus/ocmetrics: ignore io.EOF on JSON upload

### DIFF
--- a/receiver/opencensusreceiver/ocmetrics/opencensus.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus.go
@@ -17,6 +17,7 @@ package ocmetrics
 import (
 	"context"
 	"errors"
+	"io"
 	"time"
 
 	"google.golang.org/api/support/bundler"
@@ -110,6 +111,11 @@ func (ocr *Receiver) Export(mes agentmetricspb.MetricsService_ExportServer) erro
 
 		recv, err = mes.Recv()
 		if err != nil {
+			if err == io.EOF {
+				// Do not return EOF as an error so that grpc-gateway calls get an empty
+				// response with HTTP status code 200 rather than a 500 error with EOF.
+				return nil
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
When the grpc-gateway was added to this receiver/opencensus
Trace receiver in OpenCensus-Service PR
https://github.com/census-instrumentation/opencensus-service/pull/270,
we recognized that browsers and other sources that send JSON
in one burst won't stream so would encounter an io.EOF.
This PR makes the metrics receiver replicate that behavior.

Fixes #178