### PR TITLE
Honor "disabled" config flag

### DIFF
--- a/config/configmodels/configmodels.go
+++ b/config/configmodels/configmodels.go
@@ -49,6 +49,7 @@ type NamedEntity interface {
 // interface and will typically embed ReceiverSettings struct or a struct that extends it.
 type Receiver interface {
 	NamedEntity
+	IsEnabled() bool
 	Type() string
 	SetType(typeStr string)
 }
@@ -59,6 +60,7 @@ type Receivers map[string]Receiver
 // Exporter is the configuration of an exporter.
 type Exporter interface {
 	NamedEntity
+	IsEnabled() bool
 	Type() string
 	SetType(typeStr string)
 }
@@ -70,6 +72,7 @@ type Exporters map[string]Exporter
 // interface and will typically embed ProcessorSettings struct or a struct that extends it.
 type Processor interface {
 	NamedEntity
+	IsEnabled() bool
 	Type() string
 	SetType(typeStr string)
 }
@@ -141,7 +144,7 @@ const (
 type ReceiverSettings struct {
 	TypeVal             string `mapstructure:"-"`
 	NameVal             string `mapstructure:"-"`
-	Enabled             bool   `mapstructure:"enabled"`
+	Disabled            bool   `mapstructure:"disabled"`
 	Endpoint            string `mapstructure:"endpoint"`
 	DisableBackPressure bool   `mapstructure:"disable-backpressure"`
 }
@@ -166,6 +169,13 @@ func (rs *ReceiverSettings) SetType(typeStr string) {
 	rs.TypeVal = typeStr
 }
 
+// IsEnabled returns true if the entity is enabled.
+func (rs *ReceiverSettings) IsEnabled() bool {
+	// Note: we use Disabled bool so that the default of false results in
+	// entity being enabled by default.
+	return !rs.Disabled
+}
+
 // BackPressureSetting gets the back pressure setting of the configuration.
 func (rs *ReceiverSettings) BackPressureSetting() BackPressureSetting {
 	if rs.DisableBackPressure {
@@ -177,9 +187,9 @@ func (rs *ReceiverSettings) BackPressureSetting() BackPressureSetting {
 // ExporterSettings defines common settings for an exporter configuration.
 // Specific exporters can embed this struct and extend it with more fields if needed.
 type ExporterSettings struct {
-	TypeVal string `mapstructure:"-"`
-	NameVal string `mapstructure:"-"`
-	Enabled bool   `mapstructure:"enabled"`
+	TypeVal  string `mapstructure:"-"`
+	NameVal  string `mapstructure:"-"`
+	Disabled bool   `mapstructure:"disabled"`
 }
 
 var _ Exporter = (*ExporterSettings)(nil)
@@ -204,12 +214,17 @@ func (es *ExporterSettings) SetType(typeStr string) {
 	es.TypeVal = typeStr
 }
 
+// IsEnabled returns true if the entity is enabled.
+func (es *ExporterSettings) IsEnabled() bool {
+	return !es.Disabled
+}
+
 // ProcessorSettings defines common settings for a processor configuration.
 // Specific processors can embed this struct and extend it with more fields if needed.
 type ProcessorSettings struct {
-	TypeVal string `mapstructure:"-"`
-	NameVal string `mapstructure:"-"`
-	Enabled bool   `mapstructure:"enabled"`
+	TypeVal  string `mapstructure:"-"`
+	NameVal  string `mapstructure:"-"`
+	Disabled bool   `mapstructure:"disabled"`
 }
 
 // Name gets the processor name.
@@ -230,6 +245,11 @@ func (proc *ProcessorSettings) Type() string {
 // SetType sets the processor type.
 func (proc *ProcessorSettings) SetType(typeStr string) {
 	proc.TypeVal = typeStr
+}
+
+// IsEnabled returns true if the entity is enabled.
+func (proc *ProcessorSettings) IsEnabled() bool {
+	return !proc.Disabled
 }
 
 var _ Processor = (*ProcessorSettings)(nil)

--- a/config/configv2_test.go
+++ b/config/configv2_test.go
@@ -36,77 +36,84 @@ func TestDecodeConfig(t *testing.T) {
 	}
 
 	// Verify receivers
-	assert.Equal(t, len(config.Receivers), 2, "Incorrect receivers count")
+	assert.Equal(t, 2, len(config.Receivers), "Incorrect receivers count")
 
-	assert.Equal(t, config.Receivers["examplereceiver"],
+	assert.Equal(t,
 		&ExampleReceiver{
 			ReceiverSettings: configmodels.ReceiverSettings{
 				TypeVal:  "examplereceiver",
 				NameVal:  "examplereceiver",
 				Endpoint: "localhost:1000",
-				Enabled:  false,
 			},
 			ExtraSetting: "some string",
-		}, "Did not load receiver config correctly")
+		},
+		config.Receivers["examplereceiver"],
+		"Did not load receiver config correctly")
 
-	assert.Equal(t, config.Receivers["examplereceiver/myreceiver"],
+	assert.Equal(t,
 		&ExampleReceiver{
 			ReceiverSettings: configmodels.ReceiverSettings{
 				TypeVal:  "examplereceiver",
 				NameVal:  "examplereceiver/myreceiver",
 				Endpoint: "127.0.0.1:12345",
-				Enabled:  true,
 			},
 			ExtraSetting: "some string",
-		}, "Did not load receiver config correctly")
+		},
+		config.Receivers["examplereceiver/myreceiver"],
+		"Did not load receiver config correctly")
 
 	// Verify exporters
-	assert.Equal(t, len(config.Exporters), 2, "Incorrect exporters count")
+	assert.Equal(t, 2, len(config.Exporters), "Incorrect exporters count")
 
-	assert.Equal(t, config.Exporters["exampleexporter"],
+	assert.Equal(t,
 		&ExampleExporter{
 			ExporterSettings: configmodels.ExporterSettings{
 				NameVal: "exampleexporter",
 				TypeVal: "exampleexporter",
-				Enabled: false,
 			},
 			ExtraSetting: "some export string",
-		}, "Did not load exporter config correctly")
+		},
+		config.Exporters["exampleexporter"],
+		"Did not load exporter config correctly")
 
-	assert.Equal(t, config.Exporters["exampleexporter/myexporter"],
+	assert.Equal(t,
 		&ExampleExporter{
 			ExporterSettings: configmodels.ExporterSettings{
 				NameVal: "exampleexporter/myexporter",
 				TypeVal: "exampleexporter",
-				Enabled: true,
 			},
 			ExtraSetting: "some export string 2",
-		}, "Did not load exporter config correctly")
+		},
+		config.Exporters["exampleexporter/myexporter"],
+		"Did not load exporter config correctly")
 
 	// Verify Processors
-	assert.Equal(t, len(config.Processors), 1, "Incorrect processors count")
+	assert.Equal(t, 1, len(config.Processors), "Incorrect processors count")
 
-	assert.Equal(t, config.Processors["exampleprocessor"],
+	assert.Equal(t,
 		&ExampleProcessor{
 			ProcessorSettings: configmodels.ProcessorSettings{
 				TypeVal: "exampleprocessor",
 				NameVal: "exampleprocessor",
-				Enabled: false,
 			},
 			ExtraSetting: "some export string",
-		}, "Did not load processor config correctly")
+		},
+		config.Processors["exampleprocessor"],
+		"Did not load processor config correctly")
 
 	// Verify Pipelines
-	assert.Equal(t, len(config.Pipelines), 1, "Incorrect pipelines count")
+	assert.Equal(t, 1, len(config.Pipelines), "Incorrect pipelines count")
 
-	assert.Equal(t, config.Pipelines["traces"],
+	assert.Equal(t,
 		&configmodels.Pipeline{
 			Name:       "traces",
 			InputType:  configmodels.TracesDataType,
 			Receivers:  []string{"examplereceiver"},
 			Processors: []string{"exampleprocessor"},
 			Exporters:  []string{"exampleexporter"},
-		}, "Did not load pipeline config correctly")
+		},
+		config.Pipelines["traces"],
+		"Did not load pipeline config correctly")
 }
 
 func TestDecodeConfig_MultiProto(t *testing.T) {
@@ -122,43 +129,43 @@ func TestDecodeConfig_MultiProto(t *testing.T) {
 	}
 
 	// Verify receivers
-	assert.Equal(t, len(config.Receivers), 2, "Incorrect receivers count")
+	assert.Equal(t, 2, len(config.Receivers), "Incorrect receivers count")
 
-	assert.Equal(t, config.Receivers["multireceiver"],
+	assert.Equal(t,
 		&MultiProtoReceiver{
 			TypeVal: "multireceiver",
 			NameVal: "multireceiver",
 			Protocols: map[string]MultiProtoReceiverOneCfg{
 				"http": {
-					Enabled:      false,
 					Endpoint:     "example.com:8888",
 					ExtraSetting: "extra string 1",
 				},
 				"tcp": {
-					Enabled:      false,
 					Endpoint:     "omnition.com:9999",
 					ExtraSetting: "extra string 2",
 				},
 			},
-		}, "Did not load receiver config correctly")
+		},
+		config.Receivers["multireceiver"],
+		"Did not load receiver config correctly")
 
-	assert.Equal(t, config.Receivers["multireceiver/myreceiver"],
+	assert.Equal(t,
 		&MultiProtoReceiver{
 			TypeVal: "multireceiver",
 			NameVal: "multireceiver/myreceiver",
 			Protocols: map[string]MultiProtoReceiverOneCfg{
 				"http": {
-					Enabled:      true,
 					Endpoint:     "127.0.0.1:12345",
 					ExtraSetting: "some string 1",
 				},
 				"tcp": {
-					Enabled:      true,
 					Endpoint:     "0.0.0.0:4567",
 					ExtraSetting: "some string 2",
 				},
 			},
-		}, "Did not load receiver config correctly")
+		},
+		config.Receivers["multireceiver/myreceiver"],
+		"Did not load receiver config correctly")
 }
 
 func TestDecodeConfig_Invalid(t *testing.T) {
@@ -190,8 +197,8 @@ func TestDecodeConfig_Invalid(t *testing.T) {
 		{name: "unknown-processor-type", expected: errUnknownProcessorType},
 		{name: "invalid-bool-value", expected: errUnmarshalError},
 		{name: "invalid-sequence-value", expected: errUnmarshalError},
-		{name: "invalid-enabled-bool-value", expected: errUnmarshalError},
-		{name: "invalid-enabled-bool-value2", expected: errUnmarshalError},
+		{name: "invalid-disabled-bool-value", expected: errUnmarshalError},
+		{name: "invalid-disabled-bool-value2", expected: errUnmarshalError},
 		{name: "invalid-pipeline-type", expected: errInvalidPipelineType},
 		{name: "invalid-pipeline-type-and-name", expected: errInvalidTypeAndNameKey},
 		{name: "duplicate-receiver", expected: errDuplicateReceiverName},

--- a/config/example_factories.go
+++ b/config/example_factories.go
@@ -61,7 +61,6 @@ func (f *ExampleReceiverFactory) CreateDefaultConfig() configmodels.Receiver {
 		ReceiverSettings: configmodels.ReceiverSettings{
 			TypeVal:  "examplereceiver",
 			Endpoint: "localhost:1000",
-			Enabled:  false,
 		},
 		ExtraSetting: "some string",
 	}
@@ -166,9 +165,21 @@ func (rs *MultiProtoReceiver) SetType(typeStr string) {
 	rs.TypeVal = typeStr
 }
 
+// IsEnabled returns true if the entity is enabled.
+func (rs *MultiProtoReceiver) IsEnabled() bool {
+	for _, p := range rs.Protocols {
+		if !p.Disabled {
+			// If any protocol is enabled then the receiver as a whole should be enabled.
+			return true
+		}
+	}
+	// All protocols are disabled so the entire receiver can be disabled.
+	return false
+}
+
 // MultiProtoReceiverOneCfg is multi proto receiver config.
 type MultiProtoReceiverOneCfg struct {
-	Enabled      bool   `mapstructure:"enabled"`
+	Disabled     bool   `mapstructure:"disabled"`
 	Endpoint     string `mapstructure:"endpoint"`
 	ExtraSetting string `mapstructure:"extra"`
 }
@@ -193,12 +204,10 @@ func (f *MultiProtoReceiverFactory) CreateDefaultConfig() configmodels.Receiver 
 		TypeVal: "multireceiver",
 		Protocols: map[string]MultiProtoReceiverOneCfg{
 			"http": {
-				Enabled:      false,
 				Endpoint:     "example.com:8888",
 				ExtraSetting: "extra string 1",
 			},
 			"tcp": {
-				Enabled:      false,
 				Endpoint:     "omnition.com:9999",
 				ExtraSetting: "extra string 2",
 			},
@@ -246,10 +255,8 @@ func (f *ExampleExporterFactory) Type() string {
 // CreateDefaultConfig creates the default configuration for the Exporter.
 func (f *ExampleExporterFactory) CreateDefaultConfig() configmodels.Exporter {
 	return &ExampleExporter{
-		ExporterSettings: configmodels.ExporterSettings{
-			Enabled: false,
-		},
-		ExtraSetting: "some export string",
+		ExporterSettings: configmodels.ExporterSettings{},
+		ExtraSetting:     "some export string",
 	}
 }
 
@@ -300,10 +307,8 @@ func (f *ExampleProcessorFactory) Type() string {
 // CreateDefaultConfig creates the default configuration for the Processor.
 func (f *ExampleProcessorFactory) CreateDefaultConfig() configmodels.Processor {
 	return &ExampleProcessor{
-		ProcessorSettings: configmodels.ProcessorSettings{
-			Enabled: false,
-		},
-		ExtraSetting: "some export string",
+		ProcessorSettings: configmodels.ProcessorSettings{},
+		ExtraSetting:      "some export string",
 	}
 }
 

--- a/config/test_helpers.go
+++ b/config/test_helpers.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-service/exporter"
@@ -51,5 +52,5 @@ func LoadConfigFile(
 	}
 
 	// Load the config from viper
-	return Load(v, receivers, processors, exporters)
+	return Load(v, receivers, processors, exporters, zap.NewNop())
 }

--- a/config/testdata/duplicate-exporter.yaml
+++ b/config/testdata/duplicate-exporter.yaml
@@ -5,7 +5,6 @@ exporters:
   exampleexporter/ exp :
 processors:
   exampleprocessor:
-    enabled: true
 pipelines:
   traces:
     receivers: [examplereceiver]

--- a/config/testdata/duplicate-pipeline.yaml
+++ b/config/testdata/duplicate-pipeline.yaml
@@ -4,7 +4,6 @@ exporters:
   exampleexporter:
 processors:
   exampleprocessor:
-    enabled: true
 pipelines:
   traces/default:
     receivers: [examplereceiver]

--- a/config/testdata/duplicate-processor.yaml
+++ b/config/testdata/duplicate-processor.yaml
@@ -4,7 +4,6 @@ exporters:
   exampleexporter:
 processors:
   exampleprocessor/       abc:
-    enabled: true
   exampleprocessor/abc:
 pipelines:
   traces:

--- a/config/testdata/duplicate-receiver.yaml
+++ b/config/testdata/duplicate-receiver.yaml
@@ -5,7 +5,6 @@ exporters:
   exampleexporter:
 processors:
   exampleprocessor:
-    enabled: true
 pipelines:
   traces:
     receivers: [examplereceiver]

--- a/config/testdata/invalid-bool-value.yaml
+++ b/config/testdata/invalid-bool-value.yaml
@@ -4,7 +4,7 @@ exporters:
   exampleexporter:
 processors:
   exampleprocessor:
-    enabled: [2,3]
+    disabled: [2,3]
 pipelines:
   traces:
     receivers: [examplereceiver]

--- a/config/testdata/invalid-disabled-bool-value.yaml
+++ b/config/testdata/invalid-disabled-bool-value.yaml
@@ -1,8 +1,8 @@
 receivers:
   examplereceiver:
-    enabled: "string for bool"
 exporters:
   exampleexporter:
+    disabled: "string for bool"
 processors:
   exampleprocessor:
 pipelines:

--- a/config/testdata/invalid-disabled-bool-value2.yaml
+++ b/config/testdata/invalid-disabled-bool-value2.yaml
@@ -1,8 +1,8 @@
 receivers:
   examplereceiver:
+    disabled: "string for bool"
 exporters:
   exampleexporter:
-    enabled: "string for bool"
 processors:
   exampleprocessor:
 pipelines:

--- a/config/testdata/multiproto-config.yaml
+++ b/config/testdata/multiproto-config.yaml
@@ -4,16 +4,14 @@ receivers:
     protocols:
       http:
         endpoint: "127.0.0.1:12345"
-        enabled: true
         extra: "some string 1"
       tcp:
         endpoint: "0.0.0.0:4567"
-        enabled: true
         extra: "some string 2"
 
 processors:
   exampleprocessor:
-    enabled: false
+    disabled: true
 
 exporters:
   exampleexporter:

--- a/config/testdata/valid-config.yaml
+++ b/config/testdata/valid-config.yaml
@@ -1,24 +1,25 @@
 receivers:
   examplereceiver:
-    # no settings
   examplereceiver/myreceiver:
     endpoint: "127.0.0.1:12345"
-    enabled: true
     extra: "some string"
+  examplereceiver/disabled:
+    disabled: true
 
 processors:
   exampleprocessor:
-    enabled: false
+  exampleprocessor/disabled:
+    disabled: true
 
 exporters:
   exampleexporter/myexporter:
     extra: "some export string 2"
-    enabled: true
+  exampleexporter/disabled:
+    disabled: true
   exampleexporter:
-    # no settings
 
 pipelines:
   traces:
-    receivers: [examplereceiver]
-    processors: [exampleprocessor]
-    exporters: [exampleexporter]
+    receivers: [examplereceiver, examplereceiver/disabled]
+    processors: [exampleprocessor, exampleprocessor/disabled]
+    exporters: [exampleexporter/disabled, exampleexporter]

--- a/examples/demotrace/otel-agent-config.yaml
+++ b/examples/demotrace/otel-agent-config.yaml
@@ -5,20 +5,16 @@ receivers:
   opencensus:
     endpoint: 0.0.0.0:55678
     reconnection-delay: 2s
-    enabled: true
   jaeger:
     protocols:
       thrift-http:
         endpoint: "0.0.0.0:14268"
-        enabled: true
 
 
 exporters:
   opencensus:
     endpoint: "otel-collector:55678"
-    enabled: true
   logging:
-    enabled: true
 
 processors:
   batch:

--- a/examples/demotrace/otel-collector-config.yaml
+++ b/examples/demotrace/otel-collector-config.yaml
@@ -4,11 +4,9 @@ log-level: DEBUG
 receivers:
   opencensus:
     endpoint: 0.0.0.0:55678
-    enabled: true
 
 exporters:
   logging:
-    enabled: true
 
 # TODO: enable zipkin exporter when it is implemented in otelsvc
 #  zipkin:

--- a/exporter/loggingexporter/config_test.go
+++ b/exporter/loggingexporter/config_test.go
@@ -47,7 +47,6 @@ func TestLoadConfig(t *testing.T) {
 			ExporterSettings: configmodels.ExporterSettings{
 				NameVal: "logging/2",
 				TypeVal: "logging",
-				Enabled: true,
 			},
 		})
 }

--- a/exporter/loggingexporter/testdata/config.yaml
+++ b/exporter/loggingexporter/testdata/config.yaml
@@ -7,7 +7,6 @@ processors:
 exporters:
   logging:
   logging/2:
-    enabled: true
 
 
 pipelines:

--- a/exporter/opencensusexporter/config_test.go
+++ b/exporter/opencensusexporter/config_test.go
@@ -47,7 +47,6 @@ func TestLoadConfig(t *testing.T) {
 			ExporterSettings: configmodels.ExporterSettings{
 				NameVal: "opencensus/2",
 				TypeVal: "opencensus",
-				Enabled: true,
 			},
 			Headers: map[string]string{
 				"can you have a . here?": "F0000000-0000-0000-0000-000000000000",

--- a/exporter/opencensusexporter/testdata/config.yaml
+++ b/exporter/opencensusexporter/testdata/config.yaml
@@ -7,7 +7,6 @@ processors:
 exporters:
   opencensus:
   opencensus/2:
-    enabled: true
     endpoint: "1.2.3.4:1234"
     compression: "on"
     num-workers: 123

--- a/exporter/prometheusexporter/config_test.go
+++ b/exporter/prometheusexporter/config_test.go
@@ -47,7 +47,6 @@ func TestLoadConfig(t *testing.T) {
 			ExporterSettings: configmodels.ExporterSettings{
 				NameVal: "prometheus/2",
 				TypeVal: "prometheus",
-				Enabled: true,
 			},
 			Endpoint:  "1.2.3.4:1234",
 			Namespace: "test-space",

--- a/exporter/prometheusexporter/testdata/config.yaml
+++ b/exporter/prometheusexporter/testdata/config.yaml
@@ -7,7 +7,6 @@ processors:
 exporters:
   prometheus:
   prometheus/2:
-    enabled: true
     endpoint: "1.2.3.4:1234"
     namespace: test-space
     const_labels:

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -44,3 +44,15 @@ func (rs *Config) Type() string {
 func (rs *Config) SetType(typeStr string) {
 	rs.TypeVal = typeStr
 }
+
+// IsEnabled returns true if the entity is enabled.
+func (rs *Config) IsEnabled() bool {
+	for _, p := range rs.Protocols {
+		if p.IsEnabled() {
+			// If any protocol is enabled then the receiver as a whole should be enabled.
+			return true
+		}
+	}
+	// All protocols are disabled so the entire receiver can be disabled.
+	return false
+}

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -50,11 +50,10 @@ func TestLoadConfig(t *testing.T) {
 			NameVal: "jaeger/customname",
 			Protocols: map[string]*configmodels.ReceiverSettings{
 				"thrift-http": {
-					Enabled:  false,
+					Disabled: true,
 					Endpoint: "127.0.0.1:3456",
 				},
 				"thrift-tchannel": {
-					Enabled:  true,
 					Endpoint: "0.0.0.0:123",
 				},
 			},

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -65,11 +65,9 @@ func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 		NameVal: typeStr,
 		Protocols: map[string]*configmodels.ReceiverSettings{
 			protoThriftTChannel: {
-				Enabled:  false,
 				Endpoint: defaultTChannelBindEndpoint,
 			},
 			protoThriftHTTP: {
-				Enabled:  false,
 				Endpoint: defaultHTTPBindEndpoint,
 			},
 		},
@@ -95,7 +93,7 @@ func (f *Factory) CreateTraceReceiver(
 	config := Configuration{}
 
 	// Set ports
-	if protoHTTP != nil {
+	if protoHTTP != nil && protoHTTP.IsEnabled() {
 		var err error
 		config.CollectorHTTPPort, err = extractPortFromEndpoint(protoHTTP.Endpoint)
 		if err != nil {
@@ -103,7 +101,7 @@ func (f *Factory) CreateTraceReceiver(
 		}
 	}
 
-	if protoTChannel != nil {
+	if protoTChannel != nil && protoTChannel.IsEnabled() {
 		var err error
 		config.CollectorThriftPort, err = extractPortFromEndpoint(protoTChannel.Endpoint)
 		if err != nil {
@@ -114,7 +112,7 @@ func (f *Factory) CreateTraceReceiver(
 	if (protoHTTP == nil && protoTChannel == nil) ||
 		(config.CollectorHTTPPort == 0 && config.CollectorThriftPort == 0) {
 		return nil, errors.New("either " + protoThriftHTTP + " or " + protoThriftTChannel +
-			" protocol endpoint with non-zero port must be defined for " + typeStr + " receiver")
+			" protocol endpoint with non-zero port must be enabled for " + typeStr + " receiver")
 	}
 
 	// Jaeger receiver implementation currently does not allow specifying which interface

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -4,9 +4,9 @@ receivers:
     protocols:
       thrift-http:
         endpoint: "127.0.0.1:3456"
+        disabled: true
       thrift-tchannel:
         endpoint: "0.0.0.0:123"
-        enabled: true
 
 processors:
   exampleprocessor:

--- a/receiver/opencensusreceiver/config_test.go
+++ b/receiver/opencensusreceiver/config_test.go
@@ -59,7 +59,6 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal:  typeStr,
 				NameVal:  "opencensus/keepalive",
 				Endpoint: "127.0.0.1:55678",
-				Enabled:  true,
 			},
 			Keepalive: &serverParametersAndEnforcementPolicy{
 				ServerParameters: &keepaliveServerParameters{
@@ -80,7 +79,6 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal:             typeStr,
 				NameVal:             "opencensus/nobackpressure",
 				Endpoint:            "127.0.0.1:55678",
-				Enabled:             true,
 				DisableBackPressure: true,
 			},
 			MaxRecvMsgSizeMiB:    32,

--- a/receiver/opencensusreceiver/config_test.go
+++ b/receiver/opencensusreceiver/config_test.go
@@ -50,7 +50,6 @@ func TestLoadConfig(t *testing.T) {
 			TypeVal:  typeStr,
 			NameVal:  "opencensus/customname",
 			Endpoint: "0.0.0.0:9090",
-			Enabled:  true,
 		})
 
 	r2 := cfg.Receivers["opencensus/keepalive"].(*Config)

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -51,7 +51,6 @@ func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 			TypeVal:  typeStr,
 			NameVal:  typeStr,
 			Endpoint: "127.0.0.1:55678",
-			Enabled:  true,
 		},
 	}
 }

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -57,7 +57,6 @@ func TestCreateTraceReceiver(t *testing.T) {
 		TypeVal:  typeStr,
 		NameVal:  typeStr,
 		Endpoint: endpoint,
-		Enabled:  true,
 	}
 	tests := []struct {
 		name    string
@@ -77,7 +76,6 @@ func TestCreateTraceReceiver(t *testing.T) {
 					TypeVal:  typeStr,
 					NameVal:  typeStr,
 					Endpoint: "127.0.0.1:112233",
-					Enabled:  true,
 				},
 			},
 			wantErr: true,
@@ -120,7 +118,6 @@ func TestCreateMetricReceiver(t *testing.T) {
 		TypeVal:  typeStr,
 		NameVal:  typeStr,
 		Endpoint: endpoint,
-		Enabled:  true,
 	}
 	tests := []struct {
 		name    string
@@ -140,7 +137,6 @@ func TestCreateMetricReceiver(t *testing.T) {
 					TypeVal:  typeStr,
 					NameVal:  typeStr,
 					Endpoint: "327.0.0.1:1122",
-					Enabled:  true,
 				},
 			},
 			wantErr: true,

--- a/receiver/zipkinreceiver/config_test.go
+++ b/receiver/zipkinreceiver/config_test.go
@@ -50,7 +50,6 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal:             typeStr,
 				NameVal:             "zipkin/customname",
 				Endpoint:            "127.0.0.1:8765",
-				Enabled:             true,
 				DisableBackPressure: true,
 			},
 		})

--- a/receiver/zipkinreceiver/testdata/config.yaml
+++ b/receiver/zipkinreceiver/testdata/config.yaml
@@ -2,7 +2,6 @@ receivers:
   zipkin:
   zipkin/customname:
     endpoint: "127.0.0.1:8765"
-    enabled: true
     disable-backpressure: true
 
 processors:

--- a/service/builder/exporters_builder_test.go
+++ b/service/builder/exporters_builder_test.go
@@ -40,7 +40,6 @@ func TestExportersBuilder_Build(t *testing.T) {
 				ExporterSettings: configmodels.ExporterSettings{
 					NameVal: "opencensus",
 					TypeVal: "opencensus",
-					Enabled: true,
 				},
 				Endpoint: "0.0.0.0:12345",
 			},

--- a/service/builder/testdata/pipelines_builder.yaml
+++ b/service/builder/testdata/pipelines_builder.yaml
@@ -1,15 +1,8 @@
 receivers:
   examplereceiver:
-    enabled: true
-
   examplereceiver/2:
-    enabled: true
-
   examplereceiver/3:
-    enabled: true
-
   examplereceiver/multi:
-    enabled: true
 
 processors:
   add-attributes:
@@ -18,10 +11,7 @@ processors:
 
 exporters:
   exampleexporter:
-    enabled: true
-
   exampleexporter/2:
-    enabled: true
 
 pipelines:
   traces:

--- a/service/service.go
+++ b/service/service.go
@@ -208,7 +208,7 @@ func (app *Application) setupPipelines() {
 	app.logger.Info("Loading configuration...")
 
 	// Load configuration.
-	cfg, err := config.Load(app.v, app.receiverFactories, app.processorFactories, app.exporterFactories)
+	cfg, err := config.Load(app.v, app.receiverFactories, app.processorFactories, app.exporterFactories, app.logger)
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %v", err)
 	}

--- a/service/testdata/otelsvc-config.yaml
+++ b/service/testdata/otelsvc-config.yaml
@@ -1,19 +1,14 @@
 receivers:
   jaeger:
-    enabled: true
 
 exporters:
   opencensus:
     endpoint: "locahost:55678"
-    enabled: true
 
 processors:
   add-attributes:
-    enabled: true
   queued-retry:
-    enabled: true
   batch:
-    enabled: true
 
 pipelines:
   traces:

--- a/testbed/tests/testdata/agent-config.yaml
+++ b/testbed/tests/testdata/agent-config.yaml
@@ -4,16 +4,13 @@ receivers:
     protocols:
       thrift-http:
         endpoint: "*:14268"
-        enabled: true
 
 exporters:
   opencensus:
     endpoint: "127.0.0.1:56565"
-    enabled: true
 
 processors:
   add-attributes:
-    enabled: true
 
 pipelines:
   traces:


### PR DESCRIPTION
We previously had "enabled" config flag which was not honored.
This now implements "disabled" config flag which is honored.

We decided to use "disabled" instead of "enabled" since it is
more common to have enabled items than disabled items in the config
and this reduces litter in the config file.

Github issue: https://github.com/open-telemetry/opentelemetry-service/issues/113