### PR TITLE
Add queued-retry and add-attributes to perf tests

### DIFF
--- a/examples/demotrace/otel-agent-config.yaml
+++ b/examples/demotrace/otel-agent-config.yaml
@@ -4,7 +4,6 @@ log-level: DEBUG
 receivers:
   opencensus:
     endpoint: 0.0.0.0:55678
-    reconnection-delay: 2s
   jaeger:
     protocols:
       thrift-http:

--- a/examples/demotrace/otel-agent-config.yaml
+++ b/examples/demotrace/otel-agent-config.yaml
@@ -4,6 +4,7 @@ log-level: DEBUG
 receivers:
   opencensus:
     endpoint: 0.0.0.0:55678
+    reconnection-delay: 2s
   jaeger:
     protocols:
       thrift-http:

--- a/testbed/testbed/options.go
+++ b/testbed/testbed/options.go
@@ -17,19 +17,26 @@
 
 package testbed
 
-// TestCaseOption defines a TestCase option
+// TestCaseOption defines a TestCase option.
 type TestCaseOption struct {
 	option func(t *TestCase)
 }
 
-// Apply takes a TestCase and runs the option function on it
+// Apply takes a TestCase and runs the option function on it.
 func (o TestCaseOption) Apply(t *TestCase) {
 	o.option(t)
 }
 
-// WithSkipResults option disables writing out results file for a TestCase
+// WithSkipResults option disables writing out results file for a TestCase.
 func WithSkipResults() TestCaseOption {
 	return TestCaseOption{func(t *TestCase) {
 		t.skipResults = true
+	}}
+}
+
+// WithConfigFile allows a custom configuration file for TestCase.
+func WithConfigFile(file string) TestCaseOption {
+	return TestCaseOption{func(t *TestCase) {
+		t.agentConfigFile = file
 	}}
 }

--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -88,8 +88,14 @@ func NewTestCase(t *testing.T, opts ...TestCaseOption) *TestCase {
 	// Set default resource check period.
 	tc.resourceSpec.resourceCheckPeriod = 3 * time.Second
 
-	// Locations of agent config and load generator spec files.
-	tc.agentConfigFile, err = filepath.Abs(path.Join("testdata", "agent-config.yaml"))
+	configFile := tc.agentConfigFile
+	if configFile == "" {
+		// Use the default config file.
+		configFile = path.Join("testdata", "agent-config.yaml")
+	}
+
+	// Ensure that the config file is an absolute path.
+	tc.agentConfigFile, err = filepath.Abs(configFile)
 	if err != nil {
 		tc.t.Fatalf("Cannot resolve filename: %s", err.Error())
 	}

--- a/testbed/tests/perf_test.go
+++ b/testbed/tests/perf_test.go
@@ -93,7 +93,7 @@ func TestNoBackend10kSPS(t *testing.T) {
 	defer tc.Stop()
 
 	tc.SetExpectedMaxCPU(200)
-	tc.SetExpectedMaxRAM(150)
+	tc.SetExpectedMaxRAM(200)
 
 	tc.StartAgent()
 	tc.StartLoad(testbed.LoadOptions{SpansPerSecond: 10000})

--- a/testbed/tests/perf_test.go
+++ b/testbed/tests/perf_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -107,11 +108,11 @@ type testCase struct {
 	expectedMaxRAM uint32
 }
 
-func test1000SPSWithAttributes(t *testing.T, args []string, tests []testCase) {
+func test1000SPSWithAttributes(t *testing.T, args []string, tests []testCase, opts ...testbed.TestCaseOption) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%d*%dbytes", test.attrCount, test.attrSizeByte), func(t *testing.T) {
 
-			tc := testbed.NewTestCase(t)
+			tc := testbed.NewTestCase(t, opts...)
 			defer tc.Stop()
 
 			tc.SetExpectedMaxCPU(test.expectedMaxCPU)
@@ -210,4 +211,39 @@ func TestBallast1000SPSWithAttributes(t *testing.T) {
 			expectedMaxRAM: 2000,
 		},
 	})
+}
+
+func TestBallast1000SPSWithAttributesAddAttributesProcessor(t *testing.T) {
+	args := []string{"--mem-ballast-size-mib", "1000"}
+	test1000SPSWithAttributes(
+		t,
+		args,
+		[]testCase{
+			{
+				attrCount:      0,
+				attrSizeByte:   0,
+				expectedMaxCPU: 30,
+				expectedMaxRAM: 2000,
+			},
+			{
+				attrCount:      100,
+				attrSizeByte:   50,
+				expectedMaxCPU: 80,
+				expectedMaxRAM: 2000,
+			},
+			{
+				attrCount:      10,
+				attrSizeByte:   1000,
+				expectedMaxCPU: 80,
+				expectedMaxRAM: 2000,
+			},
+			{
+				attrCount:      20,
+				attrSizeByte:   5000,
+				expectedMaxCPU: 120,
+				expectedMaxRAM: 2000,
+			},
+		},
+		testbed.WithConfigFile(path.Join("testdata", "add-attributes-config.yaml")),
+	)
 }

--- a/testbed/tests/perf_test.go
+++ b/testbed/tests/perf_test.go
@@ -93,7 +93,7 @@ func TestNoBackend10kSPS(t *testing.T) {
 	defer tc.Stop()
 
 	tc.SetExpectedMaxCPU(200)
-	tc.SetExpectedMaxRAM(50)
+	tc.SetExpectedMaxRAM(150)
 
 	tc.StartAgent()
 	tc.StartLoad(testbed.LoadOptions{SpansPerSecond: 10000})

--- a/testbed/tests/testdata/add-attributes-config.yaml
+++ b/testbed/tests/testdata/add-attributes-config.yaml
@@ -4,20 +4,17 @@ receivers:
     protocols:
       thrift-http:
         endpoint: "*:14268"
-        enabled: true
 
 exporters:
   opencensus:
     endpoint: "127.0.0.1:56565"
-    enabled: true
 
 processors:
   batch:
   queued-retry:
   add-attributes:
-    enabled: true
     attrib.key00: 123
-    attrib.key01: "a large name for this attribute"
+    attrib.key01: "a small string for this attribute"
     attrib.key02: true
     region: test-region
     data-center: test-datacenter

--- a/testbed/tests/testdata/add-attributes-config.yaml
+++ b/testbed/tests/testdata/add-attributes-config.yaml
@@ -10,7 +10,6 @@ exporters:
     endpoint: "127.0.0.1:56565"
 
 processors:
-  batch:
   queued-retry:
   add-attributes:
     attrib.key00: 123
@@ -22,5 +21,5 @@ processors:
 pipelines:
   traces:
     receivers: [jaeger]
-    processors: [add-attributes]
+    processors: [add-attributes,queued-retry]
     exporters: [opencensus]

--- a/testbed/tests/testdata/add-attributes-config.yaml
+++ b/testbed/tests/testdata/add-attributes-config.yaml
@@ -4,15 +4,23 @@ receivers:
     protocols:
       thrift-http:
         endpoint: "*:14268"
+        enabled: true
 
 exporters:
   opencensus:
     endpoint: "127.0.0.1:56565"
+    enabled: true
 
 processors:
   batch:
   queued-retry:
   add-attributes:
+    enabled: true
+    attrib.key00: 123
+    attrib.key01: "a large name for this attribute"
+    attrib.key02: true
+    region: test-region
+    data-center: test-datacenter
 
 pipelines:
   traces:

--- a/testbed/tests/testdata/agent-config.yaml
+++ b/testbed/tests/testdata/agent-config.yaml
@@ -10,12 +10,11 @@ exporters:
     endpoint: "127.0.0.1:56565"
 
 processors:
-  batch:
-  queued-retry:
   add-attributes:
+  queued-retry:
 
 pipelines:
   traces:
     receivers: [jaeger]
-    processors: [add-attributes]
+    processors: [add-attributes,queued-retry]
     exporters: [opencensus]


### PR DESCRIPTION
The typical usage is expected to have both the batcher and the queued-retry so changing the perf tests to use the queued-retry. The use of the batcher needs a more careful change since it introduces a delay on the arrival of spans that breaks the basic tests.

Also adding a test with addattributesprocessor that requires a different configuration file, the intention here is that adding this processor should not cause major difference between not having it enabled.