### PR TITLE
This installs addlicense tool with `make install-tools` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ vet:
 .PHONY: install-tools
 install-tools:
 	go install golang.org/x/lint/golint
+	go install github.com/google/addlicense
 
 .PHONY: otelsvc
 otelsvc:


### PR DESCRIPTION
The tool was added as a dependency and my local build started failing because of the missing `addlicense` command. This should make it easy to fix for others by running `make install-tools` 