### PR TITLE
Fail fast when config is not set

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -108,14 +108,14 @@ func New(
 }
 
 func (app *Application) init() {
-	var err error
-	if file := builder.GetConfigFile(app.v); file != "" {
-		app.v.SetConfigFile(file)
-		err := app.v.ReadInConfig()
-		if err != nil {
-			log.Fatalf("Error loading config file %q: %v", file, err)
-			return
-		}
+	file := builder.GetConfigFile(app.v)
+	if file == "" {
+		log.Fatalf("Config file not specified")
+	}
+	app.v.SetConfigFile(file)
+	err := app.v.ReadInConfig()
+	if err != nil {
+		log.Fatalf("Error loading config file %q: %v", file, err)
 	}
 	app.logger, err = newLogger(app.v)
 	if err != nil {


### PR DESCRIPTION
Currently if flag "--config" is not specified, an error will be returned saying "Cannot load configuration: must have at least one pipeline", which is a bit confusing.