### PR TITLE
Add Zipkin exporter factory

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -20,6 +20,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/exporter/loggingexporter"
 	"github.com/open-telemetry/opentelemetry-service/exporter/opencensusexporter"
 	"github.com/open-telemetry/opentelemetry-service/exporter/prometheusexporter"
+	"github.com/open-telemetry/opentelemetry-service/exporter/zipkinexporter"
 	"github.com/open-telemetry/opentelemetry-service/oterr"
 	"github.com/open-telemetry/opentelemetry-service/processor"
 	"github.com/open-telemetry/opentelemetry-service/processor/addattributesprocessor"
@@ -58,6 +59,7 @@ func Components() (
 		&opencensusexporter.Factory{},
 		&prometheusexporter.Factory{},
 		&loggingexporter.Factory{},
+		&zipkinexporter.Factory{},
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/defaults/defaults_test.go
+++ b/defaults/defaults_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/exporter/loggingexporter"
 	"github.com/open-telemetry/opentelemetry-service/exporter/opencensusexporter"
 	"github.com/open-telemetry/opentelemetry-service/exporter/prometheusexporter"
+	"github.com/open-telemetry/opentelemetry-service/exporter/zipkinexporter"
 	"github.com/open-telemetry/opentelemetry-service/processor"
 	"github.com/open-telemetry/opentelemetry-service/processor/addattributesprocessor"
 	"github.com/open-telemetry/opentelemetry-service/processor/attributekeyprocessor"
@@ -57,6 +58,7 @@ func TestDefaultComponents(t *testing.T) {
 		"opencensus": &opencensusexporter.Factory{},
 		"prometheus": &prometheusexporter.Factory{},
 		"logging":    &loggingexporter.Factory{},
+		"zipkin":     &zipkinexporter.Factory{},
 	}
 
 	receivers, processors, exporters, err := Components()

--- a/examples/demotrace/otel-collector-config.yaml
+++ b/examples/demotrace/otel-collector-config.yaml
@@ -8,7 +8,7 @@ receivers:
 exporters:
   logging:
   zipkin:
-    endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
+    http-url: "http://zipkin-all-in-one:9411/api/v2/spans"
 
 # TODO: enable jaeger exporter when it is implemented in otelsvc
 #  jaeger:

--- a/examples/demotrace/otel-collector-config.yaml
+++ b/examples/demotrace/otel-collector-config.yaml
@@ -8,7 +8,7 @@ receivers:
 exporters:
   logging:
   zipkin:
-    http-url: "http://zipkin-all-in-one:9411/api/v2/spans"
+    url: "http://zipkin-all-in-one:9411/api/v2/spans"
 
 # TODO: enable jaeger exporter when it is implemented in otelsvc
 #  jaeger:

--- a/examples/demotrace/otel-collector-config.yaml
+++ b/examples/demotrace/otel-collector-config.yaml
@@ -7,10 +7,8 @@ receivers:
 
 exporters:
   logging:
-
-# TODO: enable zipkin exporter when it is implemented in otelsvc
-#  zipkin:
-#    endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
+  zipkin:
+    endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
 
 # TODO: enable jaeger exporter when it is implemented in otelsvc
 #  jaeger:
@@ -29,5 +27,5 @@ processors:
 pipelines:
   traces:
     receivers: [opencensus]
-    exporters: [logging]
+    exporters: [logging, zipkin]
     processors: [batch, queued-retry]

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -27,7 +27,7 @@ Exports trace data to a [Zipkin](https://zipkin.io/) endpoint.
 
 The following settings can be configured:
 
-* `http-url:` URL to which the exporter is going to send Zipkin trace data. This
+* `url:` URL to which the exporter is going to send Zipkin trace data. This
 setting doesn't have a default value and must be specified in the configuration.
 
 Example:
@@ -35,5 +35,5 @@ Example:
 ```yaml
 exporters:
   zipkin:
-    http-url: "http://some.url:9411/api/v2/spans"
+    url: "http://some.url:9411/api/v2/spans"
 ```

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -27,7 +27,7 @@ Exports trace data to a [Zipkin](https://zipkin.io/) endpoint.
 
 The following settings can be configured:
 
-* `endpoint:` URL to which the exporter is going to send Zipkin trace data. This
+* `http-url:` URL to which the exporter is going to send Zipkin trace data. This
 setting doesn't have a default value and must be specified in the configuration.
 
 Example:
@@ -35,5 +35,5 @@ Example:
 ```yaml
 exporters:
   zipkin:
-    endpoint: "http://some.url:9411/api/v2/spans"
+    http-url: "http://some.url:9411/api/v2/spans"
 ```

--- a/exporter/zipkinexporter/config.go
+++ b/exporter/zipkinexporter/config.go
@@ -1,0 +1,25 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zipkinexporter
+
+import (
+	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
+)
+
+// Config defines configuration settings for the Zipkin exporter.
+type Config struct {
+	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	Endpoint                      string                   `mapstructure:"endpoint"`
+}

--- a/exporter/zipkinexporter/config.go
+++ b/exporter/zipkinexporter/config.go
@@ -22,7 +22,7 @@ import (
 type Config struct {
 	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 
-	// Endpoint is the URL to send the Zipkin trace data to (e.g.:
+	// HTTPAddress is the URL to send the Zipkin trace data to (e.g.:
 	// http://some.url:9411/api/v2/spans).
-	Endpoint string `mapstructure:"endpoint"`
+	HTTPAddress string `mapstructure:"http-url"`
 }

--- a/exporter/zipkinexporter/config.go
+++ b/exporter/zipkinexporter/config.go
@@ -22,7 +22,7 @@ import (
 type Config struct {
 	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 
-	// HTTPAddress is the URL to send the Zipkin trace data to (e.g.:
+	// The URL to send the Zipkin trace data to (e.g.:
 	// http://some.url:9411/api/v2/spans).
-	HTTPAddress string `mapstructure:"http-url"`
+	URL string `mapstructure:"url"`
 }

--- a/exporter/zipkinexporter/config.go
+++ b/exporter/zipkinexporter/config.go
@@ -21,5 +21,8 @@ import (
 // Config defines configuration settings for the Zipkin exporter.
 type Config struct {
 	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
-	Endpoint                      string                   `mapstructure:"endpoint"`
+
+	// Endpoint is the URL to send the Zipkin trace data to (e.g.:
+	// http://some.url:9411/api/v2/spans).
+	Endpoint string `mapstructure:"endpoint"`
 }

--- a/exporter/zipkinexporter/config_test.go
+++ b/exporter/zipkinexporter/config_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-service/config"
 )
@@ -42,5 +43,11 @@ func TestLoadConfig(t *testing.T) {
 	// Endpoint doesn't have a default value so set it directly.
 	defaultCfg := factory.CreateDefaultConfig().(*Config)
 	defaultCfg.Endpoint = "http://some.location.org:9411/api/v2/spans"
-	assert.Equal(t, e0, defaultCfg)
+	assert.Equal(t, defaultCfg, e0)
+
+	e1 := cfg.Exporters["zipkin/2"]
+	assert.Equal(t, "zipkin/2", e1.(*Config).Name())
+	assert.Equal(t, "https://somedest:1234/api/v2/spans", e1.(*Config).Endpoint)
+	_, _, err = factory.CreateTraceExporter(zap.NewNop(), e1)
+	require.NoError(t, err)
 }

--- a/exporter/zipkinexporter/config_test.go
+++ b/exporter/zipkinexporter/config_test.go
@@ -1,0 +1,46 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zipkinexporter
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-service/config"
+)
+
+func TestLoadConfig(t *testing.T) {
+	receivers, processors, exporters, err := config.ExampleComponents()
+	assert.Nil(t, err)
+
+	factory := &Factory{}
+	exporters[typeStr] = factory
+	cfg, err := config.LoadConfigFile(
+		t, path.Join(".", "testdata", "config.yaml"), receivers, processors, exporters,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	e0 := cfg.Exporters["zipkin"]
+
+	// Endpoint doesn't have a default value so set it directly.
+	defaultCfg := factory.CreateDefaultConfig().(*Config)
+	defaultCfg.Endpoint = "http://some.location.org:9411/api/v2/spans"
+	assert.Equal(t, e0, defaultCfg)
+}

--- a/exporter/zipkinexporter/config_test.go
+++ b/exporter/zipkinexporter/config_test.go
@@ -40,14 +40,14 @@ func TestLoadConfig(t *testing.T) {
 
 	e0 := cfg.Exporters["zipkin"]
 
-	// HTTPAddress doesn't have a default value so set it directly.
+	// URL doesn't have a default value so set it directly.
 	defaultCfg := factory.CreateDefaultConfig().(*Config)
-	defaultCfg.HTTPAddress = "http://some.location.org:9411/api/v2/spans"
+	defaultCfg.URL = "http://some.location.org:9411/api/v2/spans"
 	assert.Equal(t, defaultCfg, e0)
 
 	e1 := cfg.Exporters["zipkin/2"]
 	assert.Equal(t, "zipkin/2", e1.(*Config).Name())
-	assert.Equal(t, "https://somedest:1234/api/v2/spans", e1.(*Config).HTTPAddress)
+	assert.Equal(t, "https://somedest:1234/api/v2/spans", e1.(*Config).URL)
 	_, _, err = factory.CreateTraceExporter(zap.NewNop(), e1)
 	require.NoError(t, err)
 }

--- a/exporter/zipkinexporter/config_test.go
+++ b/exporter/zipkinexporter/config_test.go
@@ -40,14 +40,14 @@ func TestLoadConfig(t *testing.T) {
 
 	e0 := cfg.Exporters["zipkin"]
 
-	// Endpoint doesn't have a default value so set it directly.
+	// HTTPAddress doesn't have a default value so set it directly.
 	defaultCfg := factory.CreateDefaultConfig().(*Config)
-	defaultCfg.Endpoint = "http://some.location.org:9411/api/v2/spans"
+	defaultCfg.HTTPAddress = "http://some.location.org:9411/api/v2/spans"
 	assert.Equal(t, defaultCfg, e0)
 
 	e1 := cfg.Exporters["zipkin/2"]
 	assert.Equal(t, "zipkin/2", e1.(*Config).Name())
-	assert.Equal(t, "https://somedest:1234/api/v2/spans", e1.(*Config).Endpoint)
+	assert.Equal(t, "https://somedest:1234/api/v2/spans", e1.(*Config).HTTPAddress)
 	_, _, err = factory.CreateTraceExporter(zap.NewNop(), e1)
 	require.NoError(t, err)
 }

--- a/exporter/zipkinexporter/factory.go
+++ b/exporter/zipkinexporter/factory.go
@@ -1,0 +1,76 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zipkinexporter
+
+import (
+	"errors"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-service/config/configerror"
+	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-service/consumer"
+	"github.com/open-telemetry/opentelemetry-service/exporter"
+)
+
+const (
+	// The value of "type" key in configuration.
+	typeStr = "zipkin"
+)
+
+// Factory is the factory for OpenCensus exporter.
+type Factory struct {
+}
+
+// Type gets the type of the Exporter config created by this factory.
+func (f *Factory) Type() string {
+	return typeStr
+}
+
+// CreateDefaultConfig creates the default configuration for exporter.
+func (f *Factory) CreateDefaultConfig() configmodels.Exporter {
+	return &Config{
+		ExporterSettings: configmodels.ExporterSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr,
+		},
+	}
+}
+
+// CreateTraceExporter creates a trace exporter based on this config.
+func (f *Factory) CreateTraceExporter(logger *zap.Logger, config configmodels.Exporter) (consumer.TraceConsumer, exporter.StopFunc, error) {
+	cfg := config.(*Config)
+
+	if cfg.Endpoint == "" {
+		return nil, nil, errors.New("exporter config requires an Endpoint") // TODO: better error
+	}
+
+	// TODO: (@pjanotti) Move to code like the comment below in a separate PR.
+	//ze, err := exporterhelper.NewTraceExporter(
+	//	"zipkin",
+	//	ze.PushTraceData,
+	//	exporterhelper.WithSpanName("otelsvc.exporter.Zipkin.ConsumeTraceData"),
+	//	exporterhelper.WithRecordMetrics(true))
+	ze, err := newZipkinExporter(cfg.Endpoint, "<missing service name>", 0)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return ze, ze.stop, nil
+}
+
+// CreateMetricsExporter creates a metrics exporter based on this config.
+func (f *Factory) CreateMetricsExporter(logger *zap.Logger, cfg configmodels.Exporter) (consumer.MetricsConsumer, exporter.StopFunc, error) {
+	return nil, nil, configerror.ErrDataTypeIsNotSupported
+}

--- a/exporter/zipkinexporter/factory.go
+++ b/exporter/zipkinexporter/factory.go
@@ -57,12 +57,6 @@ func (f *Factory) CreateTraceExporter(logger *zap.Logger, config configmodels.Ex
 		return nil, nil, errors.New("exporter config requires a non-empty 'http-url'") // TODO: better error
 	}
 
-	// TODO: (@pjanotti) Move to code like the comment below in a separate PR.
-	//ze, err := exporterhelper.NewTraceExporter(
-	//	"zipkin",
-	//	ze.PushTraceData,
-	//	exporterhelper.WithSpanName("otelsvc.exporter.Zipkin.ConsumeTraceData"),
-	//	exporterhelper.WithRecordMetrics(true))
 	ze, err := newZipkinExporter(cfg.HTTPAddress, "<missing service name>", 0)
 	if err != nil {
 		return nil, nil, err

--- a/exporter/zipkinexporter/factory.go
+++ b/exporter/zipkinexporter/factory.go
@@ -52,8 +52,8 @@ func (f *Factory) CreateDefaultConfig() configmodels.Exporter {
 func (f *Factory) CreateTraceExporter(logger *zap.Logger, config configmodels.Exporter) (consumer.TraceConsumer, exporter.StopFunc, error) {
 	cfg := config.(*Config)
 
-	if cfg.Endpoint == "" {
-		return nil, nil, errors.New("exporter config requires an Endpoint") // TODO: better error
+	if cfg.HTTPAddress == "" {
+		return nil, nil, errors.New("exporter config requires a non-empty 'http-url'") // TODO: better error
 	}
 
 	// TODO: (@pjanotti) Move to code like the comment below in a separate PR.
@@ -62,7 +62,7 @@ func (f *Factory) CreateTraceExporter(logger *zap.Logger, config configmodels.Ex
 	//	ze.PushTraceData,
 	//	exporterhelper.WithSpanName("otelsvc.exporter.Zipkin.ConsumeTraceData"),
 	//	exporterhelper.WithRecordMetrics(true))
-	ze, err := newZipkinExporter(cfg.Endpoint, "<missing service name>", 0)
+	ze, err := newZipkinExporter(cfg.HTTPAddress, "<missing service name>", 0)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/exporter/zipkinexporter/factory.go
+++ b/exporter/zipkinexporter/factory.go
@@ -53,11 +53,11 @@ func (f *Factory) CreateDefaultConfig() configmodels.Exporter {
 func (f *Factory) CreateTraceExporter(logger *zap.Logger, config configmodels.Exporter) (consumer.TraceConsumer, exporter.StopFunc, error) {
 	cfg := config.(*Config)
 
-	if cfg.HTTPAddress == "" {
-		return nil, nil, errors.New("exporter config requires a non-empty 'http-url'") // TODO: better error
+	if cfg.URL == "" {
+		return nil, nil, errors.New("exporter config requires a non-empty 'url'") // TODO: better error
 	}
 
-	ze, err := newZipkinExporter(cfg.HTTPAddress, "<missing service name>", 0)
+	ze, err := newZipkinExporter(cfg.URL, "<missing service name>", 0)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/exporter/zipkinexporter/factory.go
+++ b/exporter/zipkinexporter/factory.go
@@ -16,6 +16,7 @@ package zipkinexporter
 
 import (
 	"errors"
+
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-service/config/configerror"

--- a/exporter/zipkinexporter/factory_test.go
+++ b/exporter/zipkinexporter/factory_test.go
@@ -51,9 +51,9 @@ func TestCreateInstanceViaFactory(t *testing.T) {
 	assert.Nil(t, ze)
 	assert.Nil(t, zeStopFn)
 
-	// Endpoint doesn't have a default value so set it directly.
+	// HTTPAddress doesn't have a default value so set it directly.
 	zeCfg := cfg.(*Config)
-	zeCfg.Endpoint = "http://some.location.org:9411/api/v2/spans"
+	zeCfg.HTTPAddress = "http://some.location.org:9411/api/v2/spans"
 	ze, zeStopFn, err = factory.CreateTraceExporter(
 		zap.NewNop(),
 		cfg)

--- a/exporter/zipkinexporter/factory_test.go
+++ b/exporter/zipkinexporter/factory_test.go
@@ -51,9 +51,9 @@ func TestCreateInstanceViaFactory(t *testing.T) {
 	assert.Nil(t, ze)
 	assert.Nil(t, zeStopFn)
 
-	// HTTPAddress doesn't have a default value so set it directly.
+	// URL doesn't have a default value so set it directly.
 	zeCfg := cfg.(*Config)
-	zeCfg.HTTPAddress = "http://some.location.org:9411/api/v2/spans"
+	zeCfg.URL = "http://some.location.org:9411/api/v2/spans"
 	ze, zeStopFn, err = factory.CreateTraceExporter(
 		zap.NewNop(),
 		cfg)

--- a/exporter/zipkinexporter/factory_test.go
+++ b/exporter/zipkinexporter/factory_test.go
@@ -1,0 +1,64 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zipkinexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-service/config/configerror"
+)
+
+func TestCreateDefaultConfig(t *testing.T) {
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig()
+	assert.NotNil(t, cfg, "failed to create default config")
+}
+
+func TestCreateMetricsExporter(t *testing.T) {
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig()
+
+	_, _, err := factory.CreateMetricsExporter(zap.NewNop(), cfg)
+	assert.Error(t, err, configerror.ErrDataTypeIsNotSupported)
+}
+
+func TestCreateInstanceViaFactory(t *testing.T) {
+	factory := Factory{}
+
+	cfg := factory.CreateDefaultConfig()
+
+	// Default config doesn't have default endpoint so creating from it should
+	// fail.
+	ze, zeStopFn, err := factory.CreateTraceExporter(
+		zap.NewNop(),
+		cfg)
+	assert.Error(t, err)
+	assert.Nil(t, ze)
+	assert.Nil(t, zeStopFn)
+
+	// Endpoint doesn't have a default value so set it directly.
+	zeCfg := cfg.(*Config)
+	zeCfg.Endpoint = "http://some.location.org:9411/api/v2/spans"
+	ze, zeStopFn, err = factory.CreateTraceExporter(
+		zap.NewNop(),
+		cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, ze)
+	assert.NotNil(t, zeStopFn)
+	assert.NoError(t, zeStopFn())
+}

--- a/exporter/zipkinexporter/testdata/config.yaml
+++ b/exporter/zipkinexporter/testdata/config.yaml
@@ -6,9 +6,9 @@ processors:
 
 exporters:
   zipkin:
-    endpoint: "http://some.location.org:9411/api/v2/spans"
+    http-url: "http://some.location.org:9411/api/v2/spans"
   zipkin/2:
-    endpoint: "https://somedest:1234/api/v2/spans"
+    http-url: "https://somedest:1234/api/v2/spans"
 
 pipelines:
   traces:

--- a/exporter/zipkinexporter/testdata/config.yaml
+++ b/exporter/zipkinexporter/testdata/config.yaml
@@ -6,9 +6,9 @@ processors:
 
 exporters:
   zipkin:
-    http-url: "http://some.location.org:9411/api/v2/spans"
+    url: "http://some.location.org:9411/api/v2/spans"
   zipkin/2:
-    http-url: "https://somedest:1234/api/v2/spans"
+    url: "https://somedest:1234/api/v2/spans"
 
 pipelines:
   traces:

--- a/exporter/zipkinexporter/testdata/config.yaml
+++ b/exporter/zipkinexporter/testdata/config.yaml
@@ -1,0 +1,17 @@
+receivers:
+  examplereceiver:
+
+processors:
+  exampleprocessor:
+
+exporters:
+  zipkin:
+    endpoint: "http://some.location.org:9411/api/v2/spans"
+  zipkin/2:
+    endpoint: "1.2.3.4:1234"
+
+pipelines:
+  traces:
+    receivers: [examplereceiver]
+    processors: [exampleprocessor]
+    exporters: [zipkin, zipkin/2]

--- a/exporter/zipkinexporter/testdata/config.yaml
+++ b/exporter/zipkinexporter/testdata/config.yaml
@@ -8,7 +8,7 @@ exporters:
   zipkin:
     endpoint: "http://some.location.org:9411/api/v2/spans"
   zipkin/2:
-    endpoint: "1.2.3.4:1234"
+    endpoint: "https://somedest:1234/api/v2/spans"
 
 pipelines:
   traces:


### PR DESCRIPTION
Add the Zipkin exporter configuration factory using the new configuration format. This does not bring many of the settings from the old configuration since they won't be used. In a sub-sequent PR the code of the exporter itself will be changed.

Closes #34