### PR TITLE
Update exporters README

### DIFF
--- a/exporter/README.md
+++ b/exporter/README.md
@@ -1,109 +1,39 @@
-A variety of exporters are available to the OpenTelemetry Service (both Agent and Collector)
+# Exporters
 
-## Collector
+A variety of exporters are available to the OpenTelemetry Service:
 
-### Intelligent Sampling
+* [Jaeger](#jaeger)
+* [Logging](#logging)
+* [OpenCensus](#opencensus)
+* [Prometheus](#prometheus)
+* [Zipkin](#zipkin)
 
-The Collector features intelligent (tail-based) sampling. In addition to different configuration
-options it features a variety of different policies.
-```yaml
-sampling:
-  mode: tail
-  # amount of time from seeing the first span in a trace until making the sampling decision
-  decision-wait: 10s
-  # maximum number of traces kept in the memory
-  num-traces: 10000
-  policies:
-    # user-defined policy name
-    my-rate-limiting:
-      # exporters the policy applies to
-      exporters:
-        - jaeger
-        - omnition
-      policy: rate-limiting
-      configuration:
-        spans-per-second: 1000
-    my-string-attribute-filter:
-      exporters:
-        - jaeger
-        - omnition
-      policy: string-attribute-filter
-      configuration:
-        key: key1
-        values:
-          - value1
-          - value2
-    my-numeric-attribute-filter:
-      exporters:
-        - jaeger
-        - omnition
-      policy: numeric-attribute-filter
-      configuration:
-        key: key1
-        min-value: 0
-        max-value: 100
-    my-always-sample:
-      exporters:
-        - jaeger
-        - omnition
-      policy: always-sample
-```
+## <a name="jaeger"></a>Jaeger 
+TODO: document settings 
 
-### Queued Exporters
+## <a name="logging"></a>Logging
+TODO: document settings 
 
-In addition to the normal `exporters`, the OpenTelemetry Collector supports a special configuration.
-`queued-exporters` offer bounded buffer retry logic for multiple destinations.
+## <a name="opencensus"></a>OpenCensus
+TODO: document settings 
+
+## <a name="prometheus"></a>Prometheus
+TODO: document settings 
+
+## <a name="zipkin"></a>Zipkin
+Exports trace data to a [Zipkin](https://zipkin.io/) endpoint.
+
+### Configuration
+
+The following settings can be configured:
+
+* `endpoint:` URL to which the exporter is going to send Zipkin trace data. This
+setting doesn't have a default value and must be specified in the configuration.
+
+Example:
 
 ```yaml
-queued-exporters:
-  omnition: # A friendly name for the processor
-    batching:
-      enable: false
-      # sets the time, in seconds, after which a batch will be sent regardless of size
-      timeout: 1
-      # number of spans which after hit, will trigger it to be sent
-      send-batch-size: 8192
-    # num-workers is the number of queue workers that will be dequeuing batches and sending them out (default is 10)
-    num-workers: 2
-    # queue-size is the maximum number of batches allowed in the queue at a given time (default is 5000)
-    queue-size: 100
-    # retry-on-failure indicates whether queue processor should retry span batches in case of processing failure (default is true)
-    retry-on-failure: true
-    # backoff-delay is the amount of time a worker waits after a failed send before retrying (default is 5 seconds)
-    backoff-delay: 3s
-    # sender-type is the type of sender used by this processor, the default is an invalid sender so it forces one to be specified
-    sender-type: jaeger-thrift-http
-    # configuration of the selected sender-type, in this example jaeger-thrift-http. Which supports 3 settings:
-    # collector-endpoint: address of Jaeger collector thrift-http endpoint
-    # headers: a map of any additional headers to be sent with each batch (e.g.: api keys, etc)
-    # timeout: the timeout for the sender to consider the operation as failed
-    jaeger-thrift-http:
-      collector-endpoint: "https://ingest.omnition.io"
-      headers: { "x-omnition-api-key": "00000000-0000-0000-0000-000000000001" }
-      timeout: 5s
-    # Non-sender exporters can now also be used by setting the exporters section in queued-exporters.
-    exporters:
-      opencensus:
-        endpoint: "127.0.0.1:55566"
-        cert-pem-file: "server_ca_public.pem" # PEM file used to enable TLS. For trusted CAs from
-                                              # system pool use "secure:" setting, see below.
-        compression: "gzip"
-        reconnection-dealy: 2s # Delay (+70% jitter) before reconnection attempt in case of error.
-        secure: true # Used to export to destinations trusted by certificates from the system pool.
-                     # "cert-pem-file:" takes precedence over this setting.
-        keepalive:
-          # Keepalive settings for gRPC clients, see https://godoc.org/google.golang.org/grpc/keepalive#ClientParameters.
-          # Recommended to be set for cases that need to support bursts of data and periods of inactivity.
-          time: 30s # After inactive for this amount to time client will send a ping to the server.
-          timeout: 5s # Amount of time that client waits for a keepalive ping response before closing the connection.
-          permit-without-stream: true # Permits the keepalive ping even if no RPCs are in use, if false no ping is sent.
-  my-org-jaeger: # A second processor with its own configuration options
-    num-workers: 2
-    queue-size: 100
-    retry-on-failure: true
-    backoff-delay: 3s
-    sender-type: jaeger-thrift-http
-    jaeger-thrift-http:
-      collector-endpoint: "http://jaeger.local:14268/api/traces"
-      timeout: 5s
+exporters:
+  zipkin:
+    endpoint: "http://some.url:9411/api/v2/spans"
 ```


### PR DESCRIPTION
Remove stale content, put in place a simple skeleton, and put information for the Zipkin exporter.

This is a follow up to a [comment](https://github.com/open-telemetry/opentelemetry-service/pull/207#pullrequestreview-268590954) on PR #207