### PR TITLE
Rename exporterhelp parameter

### DIFF
--- a/exporter/exporterhelper/constants.go
+++ b/exporter/exporterhelper/constants.go
@@ -19,8 +19,8 @@ import (
 )
 
 var (
-	// errEmptyExporterFormat is returned when an empty name is given.
-	errEmptyExporterFormat = errors.New("empty exporter format")
+	// errEmptyExporterName is returned when an empty name is given.
+	errEmptyExporterName = errors.New("empty exporterName")
 	// errNilPushTraceData is returned when a nil pushTraceData is given.
 	errNilPushTraceData = errors.New("nil pushTraceData")
 	// errNilPushMetricsData is returned when a nil pushMetricsData is given.

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -29,18 +29,18 @@ import (
 type PushMetricsData func(ctx context.Context, td consumerdata.MetricsData) (droppedMetrics int, err error)
 
 type metricsExporter struct {
-	exporterFormat  string
+	exporterName    string
 	pushMetricsData PushMetricsData
 }
 
 var _ (exporter.MetricsExporter) = (*metricsExporter)(nil)
 
 func (me *metricsExporter) MetricsExportFormat() string {
-	return me.exporterFormat
+	return me.exporterName
 }
 
 func (me *metricsExporter) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
-	exporterCtx := observability.ContextWithExporterName(ctx, me.exporterFormat)
+	exporterCtx := observability.ContextWithExporterName(ctx, me.exporterName)
 	_, err := me.pushMetricsData(exporterCtx, md)
 	return err
 }
@@ -49,9 +49,9 @@ func (me *metricsExporter) ConsumeMetricsData(ctx context.Context, md consumerda
 // If no options are passed it just adds the exporter format as a tag in the Context.
 // TODO: Add support for recordMetrics.
 // TODO: Add support for retries.
-func NewMetricsExporter(exporterFormat string, pushMetricsData PushMetricsData, options ...ExporterOption) (exporter.MetricsExporter, error) {
-	if exporterFormat == "" {
-		return nil, errEmptyExporterFormat
+func NewMetricsExporter(exporterName string, pushMetricsData PushMetricsData, options ...ExporterOption) (exporter.MetricsExporter, error) {
+	if exporterName == "" {
+		return nil, errEmptyExporterName
 	}
 
 	if pushMetricsData == nil {
@@ -65,7 +65,7 @@ func NewMetricsExporter(exporterFormat string, pushMetricsData PushMetricsData, 
 	}
 
 	return &metricsExporter{
-		exporterFormat:  exporterFormat,
+		exporterName:    exporterName,
 		pushMetricsData: pushMetricsData,
 	}, nil
 }

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -26,8 +26,8 @@ import (
 )
 
 func TestMetricsExporter_InvalidName(t *testing.T) {
-	if _, err := NewMetricsExporter("", newPushMetricsData(0, nil)); err != errEmptyExporterFormat {
-		t.Fatalf("NewMetricsExporter returns: Want %v Got %v", errEmptyExporterFormat, err)
+	if _, err := NewMetricsExporter("", newPushMetricsData(0, nil)); err != errEmptyExporterName {
+		t.Fatalf("NewMetricsExporter returns: Want %v Got %v", errEmptyExporterName, err)
 	}
 }
 

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -29,28 +29,28 @@ import (
 type PushTraceData func(ctx context.Context, td consumerdata.TraceData) (droppedSpans int, err error)
 
 type traceExporter struct {
-	exporterFormat string
-	pushTraceData  PushTraceData
+	exporterName  string
+	pushTraceData PushTraceData
 }
 
 var _ (exporter.TraceExporter) = (*traceExporter)(nil)
 
 func (te *traceExporter) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
-	exporterCtx := observability.ContextWithExporterName(ctx, te.exporterFormat)
+	exporterCtx := observability.ContextWithExporterName(ctx, te.exporterName)
 	_, err := te.pushTraceData(exporterCtx, td)
 	return err
 }
 
 func (te *traceExporter) TraceExportFormat() string {
-	return te.exporterFormat
+	return te.exporterName
 }
 
 // NewTraceExporter creates an TraceExporter that can record metrics and can wrap every request with a Span.
 // If no options are passed it just adds the exporter format as a tag in the Context.
 // TODO: Add support for retries.
-func NewTraceExporter(exporterFormat string, pushTraceData PushTraceData, options ...ExporterOption) (exporter.TraceExporter, error) {
-	if exporterFormat == "" {
-		return nil, errEmptyExporterFormat
+func NewTraceExporter(exporterName string, pushTraceData PushTraceData, options ...ExporterOption) (exporter.TraceExporter, error) {
+	if exporterName == "" {
+		return nil, errEmptyExporterName
 	}
 
 	if pushTraceData == nil {
@@ -67,8 +67,8 @@ func NewTraceExporter(exporterFormat string, pushTraceData PushTraceData, option
 	}
 
 	return &traceExporter{
-		exporterFormat: exporterFormat,
-		pushTraceData:  pushTraceData,
+		exporterName:  exporterName,
+		pushTraceData: pushTraceData,
 	}, nil
 }
 

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -36,8 +36,8 @@ const (
 )
 
 func TestTraceExporter_InvalidName(t *testing.T) {
-	if _, err := NewTraceExporter("", newPushTraceData(0, nil)); err != errEmptyExporterFormat {
-		t.Fatalf("NewTraceExporter returns: Want %v Got %v", errEmptyExporterFormat, err)
+	if _, err := NewTraceExporter("", newPushTraceData(0, nil)); err != errEmptyExporterName {
+		t.Fatalf("NewTraceExporter returns: Want %v Got %v", errEmptyExporterName, err)
 	}
 }
 


### PR DESCRIPTION
The paramater was named exportFormat but it actually used as the exporter name.