### PR TITLE
Refactor (Trace/Metrics)ExportFormat to ExporterName

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -23,20 +23,16 @@ import (
 type TraceExporter interface {
 	consumer.TraceConsumer
 
-	// TraceExportFormat gets the name of the format in which this exporter sends its data.
-	// For exporters that can export multiple signals it is recommended to encode the signal
-	// as suffix (e.g. "oc_trace").
-	TraceExportFormat() string
+	// TraceExporterName gets the name of the trace exporter.
+	TraceExporterName() string
 }
 
 // MetricsExporter composes MetricsConsumer with some additional exporter-specific functions.
 type MetricsExporter interface {
 	consumer.MetricsConsumer
 
-	// MetricsExportFormat gets the name of the format in which this exporter sends its data.
-	// For exporters that can export multiple signals it is recommended to encode the signal
-	// as suffix (e.g. "oc_metrics").
-	MetricsExportFormat() string
+	// MetricsExporterName gets the name of the metrics exporter.
+	MetricsExporterName() string
 }
 
 // Exporter is union of trace and/or metrics exporter.

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -23,21 +23,14 @@ import (
 type TraceExporter interface {
 	consumer.TraceConsumer
 
-	// TraceExporterName gets the name of the trace exporter.
-	TraceExporterName() string
+	// Name gets the name of the trace exporter.
+	Name() string
 }
 
 // MetricsExporter composes MetricsConsumer with some additional exporter-specific functions.
 type MetricsExporter interface {
 	consumer.MetricsConsumer
 
-	// MetricsExporterName gets the name of the metrics exporter.
-	MetricsExporterName() string
-}
-
-// Exporter is union of trace and/or metrics exporter.
-type Exporter interface {
-	TraceExporter
-	MetricsExporter
-	Stop() error
+	// Name gets the name of the metrics exporter.
+	Name() string
 }

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -35,7 +35,7 @@ type metricsExporter struct {
 
 var _ (exporter.MetricsExporter) = (*metricsExporter)(nil)
 
-func (me *metricsExporter) MetricsExportFormat() string {
+func (me *metricsExporter) MetricsExporterName() string {
 	return me.exporterName
 }
 

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -35,7 +35,7 @@ type metricsExporter struct {
 
 var _ (exporter.MetricsExporter) = (*metricsExporter)(nil)
 
-func (me *metricsExporter) MetricsExporterName() string {
+func (me *metricsExporter) Name() string {
 	return me.exporterName
 }
 

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -45,8 +45,8 @@ func TestMetricsExporter_Default(t *testing.T) {
 	if err := te.ConsumeMetricsData(context.Background(), td); err != nil {
 		t.Fatalf("ConsumeMetricsData returns: Want nil Got %v", err)
 	}
-	if g, w := te.MetricsExportFormat(), fakeExporterName; g != w {
-		t.Fatalf("MetricsExportFormat returns: Want %s Got %s", w, g)
+	if g, w := te.MetricsExporterName(), fakeExporterName; g != w {
+		t.Fatalf("Name returns: Want %s Got %s", w, g)
 	}
 }
 

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -45,7 +45,7 @@ func TestMetricsExporter_Default(t *testing.T) {
 	if err := te.ConsumeMetricsData(context.Background(), td); err != nil {
 		t.Fatalf("ConsumeMetricsData returns: Want nil Got %v", err)
 	}
-	if g, w := te.MetricsExporterName(), fakeExporterName; g != w {
+	if g, w := te.Name(), fakeExporterName; g != w {
 		t.Fatalf("Name returns: Want %s Got %s", w, g)
 	}
 }

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -41,7 +41,7 @@ func (te *traceExporter) ConsumeTraceData(ctx context.Context, td consumerdata.T
 	return err
 }
 
-func (te *traceExporter) TraceExportFormat() string {
+func (te *traceExporter) TraceExporterName() string {
 	return te.exporterName
 }
 

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -41,7 +41,7 @@ func (te *traceExporter) ConsumeTraceData(ctx context.Context, td consumerdata.T
 	return err
 }
 
-func (te *traceExporter) TraceExporterName() string {
+func (te *traceExporter) Name() string {
 	return te.exporterName
 }
 

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -55,8 +55,8 @@ func TestTraceExporter_Default(t *testing.T) {
 	if err := te.ConsumeTraceData(context.Background(), td); err != nil {
 		t.Fatalf("ConsumeTraceData returns: Want nil Got %v", err)
 	}
-	if g, w := te.TraceExportFormat(), fakeExporterName; g != w {
-		t.Fatalf("TraceExportFormat returns: Want %s Got %s", w, g)
+	if g, w := te.TraceExporterName(), fakeExporterName; g != w {
+		t.Fatalf("Name returns: Want %s Got %s", w, g)
 	}
 }
 
@@ -142,10 +142,10 @@ func checkRecordedMetricsForTraceExporter(t *testing.T, te exporter.TraceExporte
 		}
 	}
 
-	if err := observabilitytest.CheckValueViewExporterReceivedSpans(fakeReceiverName, te.TraceExportFormat(), numBatches*len(spans)); err != nil {
+	if err := observabilitytest.CheckValueViewExporterReceivedSpans(fakeReceiverName, te.TraceExporterName(), numBatches*len(spans)); err != nil {
 		t.Fatalf("CheckValueViewExporterReceivedSpans: Want nil Got %v", err)
 	}
-	if err := observabilitytest.CheckValueViewExporterDroppedSpans(fakeReceiverName, te.TraceExportFormat(), numBatches*droppedSpans); err != nil {
+	if err := observabilitytest.CheckValueViewExporterDroppedSpans(fakeReceiverName, te.TraceExporterName(), numBatches*droppedSpans); err != nil {
 		t.Fatalf("CheckValueViewExporterDroppedSpans: Want nil Got %v", err)
 	}
 }

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -55,7 +55,7 @@ func TestTraceExporter_Default(t *testing.T) {
 	if err := te.ConsumeTraceData(context.Background(), td); err != nil {
 		t.Fatalf("ConsumeTraceData returns: Want nil Got %v", err)
 	}
-	if g, w := te.TraceExporterName(), fakeExporterName; g != w {
+	if g, w := te.Name(), fakeExporterName; g != w {
 		t.Fatalf("Name returns: Want %s Got %s", w, g)
 	}
 }
@@ -142,10 +142,10 @@ func checkRecordedMetricsForTraceExporter(t *testing.T, te exporter.TraceExporte
 		}
 	}
 
-	if err := observabilitytest.CheckValueViewExporterReceivedSpans(fakeReceiverName, te.TraceExporterName(), numBatches*len(spans)); err != nil {
+	if err := observabilitytest.CheckValueViewExporterReceivedSpans(fakeReceiverName, te.Name(), numBatches*len(spans)); err != nil {
 		t.Fatalf("CheckValueViewExporterReceivedSpans: Want nil Got %v", err)
 	}
-	if err := observabilitytest.CheckValueViewExporterDroppedSpans(fakeReceiverName, te.TraceExporterName(), numBatches*droppedSpans); err != nil {
+	if err := observabilitytest.CheckValueViewExporterDroppedSpans(fakeReceiverName, te.Name(), numBatches*droppedSpans); err != nil {
 		t.Fatalf("CheckValueViewExporterDroppedSpans: Want nil Got %v", err)
 	}
 }

--- a/exporter/exportertest/nop_exporter.go
+++ b/exporter/exportertest/nop_exporter.go
@@ -38,16 +38,16 @@ func (ne *nopExporter) ConsumeMetricsData(ctx context.Context, md consumerdata.M
 }
 
 const (
-	nopTraceExportFormat   = "nop_trace"
-	nopMetricsExportFormat = "nop_metrics"
+	nopTraceExporterName   = "nop_trace"
+	nopMetricsExporterName = "nop_metrics"
 )
 
-func (ne *nopExporter) TraceExportFormat() string {
-	return nopTraceExportFormat
+func (ne *nopExporter) TraceExporterName() string {
+	return nopTraceExporterName
 }
 
-func (ne *nopExporter) MetricsExportFormat() string {
-	return nopMetricsExportFormat
+func (ne *nopExporter) MetricsExporterName() string {
+	return nopMetricsExporterName
 }
 
 // NewNopTraceExporter creates an TraceExporter that just drops the received data.

--- a/exporter/exportertest/nop_exporter.go
+++ b/exporter/exportertest/nop_exporter.go
@@ -24,7 +24,10 @@ import (
 // NopExporterOption represents options that can be applied to a NopExporter.
 type NopExporterOption func(*nopExporter)
 
-type nopExporter struct{ retError error }
+type nopExporter struct {
+	name     string
+	retError error
+}
 
 var _ exporter.TraceExporter = (*nopExporter)(nil)
 var _ exporter.MetricsExporter = (*nopExporter)(nil)
@@ -42,22 +45,18 @@ const (
 	nopMetricsExporterName = "nop_metrics"
 )
 
-func (ne *nopExporter) TraceExporterName() string {
-	return nopTraceExporterName
-}
-
-func (ne *nopExporter) MetricsExporterName() string {
-	return nopMetricsExporterName
+func (ne *nopExporter) Name() string {
+	return ne.name
 }
 
 // NewNopTraceExporter creates an TraceExporter that just drops the received data.
 func NewNopTraceExporter(options ...NopExporterOption) exporter.TraceExporter {
-	return newNopExporter(options...)
+	return newNopTraceExporter(options...)
 }
 
 // NewNopMetricsExporter creates an MetricsExporter that just drops the received data.
 func NewNopMetricsExporter(options ...NopExporterOption) exporter.MetricsExporter {
-	return newNopExporter(options...)
+	return newNopMetricsExporter(options...)
 }
 
 // WithReturnError returns a NopExporterOption that enforces the nop Exporters to return the given error.
@@ -67,8 +66,20 @@ func WithReturnError(retError error) NopExporterOption {
 	}
 }
 
-func newNopExporter(options ...NopExporterOption) *nopExporter {
-	ne := new(nopExporter)
+func newNopTraceExporter(options ...NopExporterOption) *nopExporter {
+	ne := &nopExporter{
+		name: nopTraceExporterName,
+	}
+	for _, opt := range options {
+		opt(ne)
+	}
+	return ne
+}
+
+func newNopMetricsExporter(options ...NopExporterOption) *nopExporter {
+	ne := &nopExporter{
+		name: nopMetricsExporterName,
+	}
 	for _, opt := range options {
 		opt(ne)
 	}

--- a/exporter/exportertest/nop_exporter_test.go
+++ b/exporter/exportertest/nop_exporter_test.go
@@ -31,8 +31,8 @@ func TestNopTraceExporter_NoErrors(t *testing.T) {
 	if err := nte.ConsumeTraceData(context.Background(), td); err != nil {
 		t.Fatalf("Wanted nil got error")
 	}
-	if nte.TraceExportFormat() != "nop_trace" {
-		t.Fatalf("Wanted nop_trace got %s", nte.TraceExportFormat())
+	if nte.TraceExporterName() != "nop_trace" {
+		t.Fatalf("Wanted nop_trace got %s", nte.TraceExporterName())
 	}
 }
 
@@ -45,8 +45,8 @@ func TestNopTraceExporter_WithErrors(t *testing.T) {
 	if got := nte.ConsumeTraceData(context.Background(), td); got != want {
 		t.Fatalf("Want %v Got %v", want, got)
 	}
-	if nte.TraceExportFormat() != "nop_trace" {
-		t.Fatalf("Wanted nop_trace got %s", nte.TraceExportFormat())
+	if nte.TraceExporterName() != "nop_trace" {
+		t.Fatalf("Wanted nop_trace got %s", nte.TraceExporterName())
 	}
 }
 
@@ -58,8 +58,8 @@ func TestNopMetricsExporter_NoErrors(t *testing.T) {
 	if err := nme.ConsumeMetricsData(context.Background(), md); err != nil {
 		t.Fatalf("Wanted nil got error")
 	}
-	if nme.MetricsExportFormat() != "nop_metrics" {
-		t.Fatalf("Wanted nop_metrics got %s", nme.MetricsExportFormat())
+	if nme.MetricsExporterName() != "nop_metrics" {
+		t.Fatalf("Wanted nop_metrics got %s", nme.MetricsExporterName())
 	}
 }
 
@@ -72,7 +72,7 @@ func TestNopMetricsExporter_WithErrors(t *testing.T) {
 	if got := nme.ConsumeMetricsData(context.Background(), md); got != want {
 		t.Fatalf("Want %v Got %v", want, got)
 	}
-	if nme.MetricsExportFormat() != "nop_metrics" {
-		t.Fatalf("Wanted nop_metrics got %s", nme.MetricsExportFormat())
+	if nme.MetricsExporterName() != "nop_metrics" {
+		t.Fatalf("Wanted nop_metrics got %s", nme.MetricsExporterName())
 	}
 }

--- a/exporter/exportertest/nop_exporter_test.go
+++ b/exporter/exportertest/nop_exporter_test.go
@@ -31,8 +31,8 @@ func TestNopTraceExporter_NoErrors(t *testing.T) {
 	if err := nte.ConsumeTraceData(context.Background(), td); err != nil {
 		t.Fatalf("Wanted nil got error")
 	}
-	if nte.TraceExporterName() != "nop_trace" {
-		t.Fatalf("Wanted nop_trace got %s", nte.TraceExporterName())
+	if nte.Name() != "nop_trace" {
+		t.Fatalf("Wanted nop_trace got %s", nte.Name())
 	}
 }
 
@@ -45,8 +45,8 @@ func TestNopTraceExporter_WithErrors(t *testing.T) {
 	if got := nte.ConsumeTraceData(context.Background(), td); got != want {
 		t.Fatalf("Want %v Got %v", want, got)
 	}
-	if nte.TraceExporterName() != "nop_trace" {
-		t.Fatalf("Wanted nop_trace got %s", nte.TraceExporterName())
+	if nte.Name() != "nop_trace" {
+		t.Fatalf("Wanted nop_trace got %s", nte.Name())
 	}
 }
 
@@ -58,8 +58,8 @@ func TestNopMetricsExporter_NoErrors(t *testing.T) {
 	if err := nme.ConsumeMetricsData(context.Background(), md); err != nil {
 		t.Fatalf("Wanted nil got error")
 	}
-	if nme.MetricsExporterName() != "nop_metrics" {
-		t.Fatalf("Wanted nop_metrics got %s", nme.MetricsExporterName())
+	if nme.Name() != "nop_metrics" {
+		t.Fatalf("Wanted nop_metrics got %s", nme.Name())
 	}
 }
 
@@ -72,7 +72,7 @@ func TestNopMetricsExporter_WithErrors(t *testing.T) {
 	if got := nme.ConsumeMetricsData(context.Background(), md); got != want {
 		t.Fatalf("Want %v Got %v", want, got)
 	}
-	if nme.MetricsExporterName() != "nop_metrics" {
-		t.Fatalf("Wanted nop_metrics got %s", nme.MetricsExporterName())
+	if nme.Name() != "nop_metrics" {
+		t.Fatalf("Wanted nop_metrics got %s", nme.Name())
 	}
 }

--- a/exporter/exportertest/sink_exporter.go
+++ b/exporter/exportertest/sink_exporter.go
@@ -45,8 +45,8 @@ const (
 	sinkMetricsExportFormat = "sink_metrics"
 )
 
-// TraceExportFormat retruns the name of this TraceExporter
-func (ste *SinkTraceExporter) TraceExportFormat() string {
+// TraceExporterName returns the name of this TraceExporter.
+func (ste *SinkTraceExporter) TraceExporterName() string {
 	return sinkTraceExportFormat
 }
 
@@ -76,8 +76,8 @@ func (sme *SinkMetricsExporter) ConsumeMetricsData(ctx context.Context, md consu
 	return nil
 }
 
-// MetricsExportFormat retruns the name of this MetricsExporter
-func (sme *SinkMetricsExporter) MetricsExportFormat() string {
+// MetricsExporterName returns the name of this MetricsExporter.
+func (sme *SinkMetricsExporter) MetricsExporterName() string {
 	return sinkMetricsExportFormat
 }
 

--- a/exporter/exportertest/sink_exporter.go
+++ b/exporter/exportertest/sink_exporter.go
@@ -45,8 +45,8 @@ const (
 	sinkMetricsExportFormat = "sink_metrics"
 )
 
-// TraceExporterName returns the name of this TraceExporter.
-func (ste *SinkTraceExporter) TraceExporterName() string {
+// Name returns the name of this TraceExporter.
+func (ste *SinkTraceExporter) Name() string {
 	return sinkTraceExportFormat
 }
 
@@ -76,8 +76,8 @@ func (sme *SinkMetricsExporter) ConsumeMetricsData(ctx context.Context, md consu
 	return nil
 }
 
-// MetricsExporterName returns the name of this MetricsExporter.
-func (sme *SinkMetricsExporter) MetricsExporterName() string {
+// Name returns the name of this MetricsExporter.
+func (sme *SinkMetricsExporter) Name() string {
 	return sinkMetricsExportFormat
 }
 

--- a/exporter/exportertest/sink_exporter_test.go
+++ b/exporter/exportertest/sink_exporter_test.go
@@ -39,8 +39,8 @@ func TestSinkTraceExporter(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Mismatches responses\nGot:\n\t%v\nWant:\n\t%v\n", got, want)
 	}
-	if sink.TraceExportFormat() != "sink_trace" {
-		t.Errorf("Wanted sink_trace got %s", sink.TraceExportFormat())
+	if sink.TraceExporterName() != "sink_trace" {
+		t.Errorf("Wanted sink_trace got %s", sink.TraceExporterName())
 	}
 }
 
@@ -60,7 +60,7 @@ func TestSinkMetricsExporter(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Mismatches responses\nGot:\n\t%v\nWant:\n\t%v\n", got, want)
 	}
-	if sink.MetricsExportFormat() != "sink_metrics" {
-		t.Errorf("Wanted sink_metrics got %s", sink.MetricsExportFormat())
+	if sink.MetricsExporterName() != "sink_metrics" {
+		t.Errorf("Wanted sink_metrics got %s", sink.MetricsExporterName())
 	}
 }

--- a/exporter/exportertest/sink_exporter_test.go
+++ b/exporter/exportertest/sink_exporter_test.go
@@ -39,8 +39,8 @@ func TestSinkTraceExporter(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Mismatches responses\nGot:\n\t%v\nWant:\n\t%v\n", got, want)
 	}
-	if sink.TraceExporterName() != "sink_trace" {
-		t.Errorf("Wanted sink_trace got %s", sink.TraceExporterName())
+	if sink.Name() != "sink_trace" {
+		t.Errorf("Wanted sink_trace got %s", sink.Name())
 	}
 }
 
@@ -60,7 +60,7 @@ func TestSinkMetricsExporter(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Mismatches responses\nGot:\n\t%v\nWant:\n\t%v\n", got, want)
 	}
-	if sink.MetricsExporterName() != "sink_metrics" {
-		t.Errorf("Wanted sink_metrics got %s", sink.MetricsExporterName())
+	if sink.Name() != "sink_metrics" {
+		t.Errorf("Wanted sink_metrics got %s", sink.Name())
 	}
 }

--- a/exporter/loggingexporter/factory.go
+++ b/exporter/loggingexporter/factory.go
@@ -51,9 +51,9 @@ func noopStopFunc() error {
 }
 
 // CreateTraceExporter creates a trace exporter based on this config.
-func (f *Factory) CreateTraceExporter(logger *zap.Logger, config configmodels.Exporter) (consumer.TraceConsumer, exporter.StopFunc, error) {
+func (f *Factory) CreateTraceExporter(logger *zap.Logger, cfg configmodels.Exporter) (consumer.TraceConsumer, exporter.StopFunc, error) {
 
-	lexp, err := NewTraceExporter(logger)
+	lexp, err := NewTraceExporter(cfg.Name(), logger)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -62,7 +62,7 @@ func (f *Factory) CreateTraceExporter(logger *zap.Logger, config configmodels.Ex
 
 // CreateMetricsExporter creates a metrics exporter based on this config.
 func (f *Factory) CreateMetricsExporter(logger *zap.Logger, cfg configmodels.Exporter) (consumer.MetricsConsumer, exporter.StopFunc, error) {
-	lexp, err := NewMetricsExporter(logger)
+	lexp, err := NewMetricsExporter(cfg.Name(), logger)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -17,41 +17,37 @@ package loggingexporter
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exporterhelper"
-	"go.uber.org/zap"
-)
-
-const (
-	traceExportFormat   = "logging_trace"
-	metricsExportFormat = "logging_metrics"
 )
 
 // NewTraceExporter creates an exporter.TraceExporter that just drops the
 // received data and logs debugging messages.
-func NewTraceExporter(logger *zap.Logger) (exporter.TraceExporter, error) {
+func NewTraceExporter(exporterName string, logger *zap.Logger) (exporter.TraceExporter, error) {
 	return exporterhelper.NewTraceExporter(
-		traceExportFormat,
+		exporterName,
 		func(ctx context.Context, td consumerdata.TraceData) (int, error) {
-			logger.Debug("loggingTraceExporter", zap.Int("#spans", len(td.Spans)))
+			logger.Debug(exporterName, zap.Int("#spans", len(td.Spans)))
 			// TODO: Add ability to record the received data
 			return 0, nil
 		},
-		exporterhelper.WithSpanName("LoggingExporter.ConsumeTraceData"), exporterhelper.WithRecordMetrics(true),
+		exporterhelper.WithSpanName(exporterName+".ConsumeTraceData"), exporterhelper.WithRecordMetrics(true),
 	)
 }
 
 // NewMetricsExporter creates an exporter.MetricsExporter that just drops the
 // received data and logs debugging messages.
-func NewMetricsExporter(logger *zap.Logger) (exporter.MetricsExporter, error) {
+func NewMetricsExporter(exporterName string, logger *zap.Logger) (exporter.MetricsExporter, error) {
 	return exporterhelper.NewMetricsExporter(
-		metricsExportFormat,
+		exporterName,
 		func(ctx context.Context, md consumerdata.MetricsData) (int, error) {
-			logger.Debug("loggingMetricsExporter", zap.Int("#metrics", len(md.Metrics)))
+			logger.Debug(exporterName, zap.Int("#metrics", len(md.Metrics)))
 			// TODO: Add ability to record the received data
 			return 0, nil
 		},
-		exporterhelper.WithSpanName("LoggingExporter.ConsumeMetricsData"), exporterhelper.WithRecordMetrics(true),
+		exporterhelper.WithSpanName(exporterName+".ConsumeMetricsData"), exporterhelper.WithRecordMetrics(true),
 	)
 }

--- a/exporter/loggingexporter/logging_exporter_test.go
+++ b/exporter/loggingexporter/logging_exporter_test.go
@@ -35,8 +35,8 @@ func TestLoggingTraceExporterNoErrors(t *testing.T) {
 	if err := lte.ConsumeTraceData(context.Background(), td); err != nil {
 		t.Fatalf("Wanted nil got %v", err)
 	}
-	if lte.TraceExporterName() != exporterName {
-		t.Errorf("Wanted %q got %q", exporterName, lte.TraceExporterName())
+	if lte.Name() != exporterName {
+		t.Errorf("Wanted %q got %q", exporterName, lte.Name())
 	}
 }
 
@@ -52,7 +52,7 @@ func TestLoggingMetricsExporterNoErrors(t *testing.T) {
 	if err := lme.ConsumeMetricsData(context.Background(), md); err != nil {
 		t.Fatalf("Wanted nil got %v", err)
 	}
-	if lme.MetricsExporterName() != exporterName {
-		t.Errorf("Wanted %q got %q", exporterName, lme.MetricsExporterName())
+	if lme.Name() != exporterName {
+		t.Errorf("Wanted %q got %q", exporterName, lme.Name())
 	}
 }

--- a/exporter/loggingexporter/logging_exporter_test.go
+++ b/exporter/loggingexporter/logging_exporter_test.go
@@ -24,7 +24,8 @@ import (
 )
 
 func TestLoggingTraceExporterNoErrors(t *testing.T) {
-	lte, err := NewTraceExporter(zap.NewNop())
+	const exporterName = "test_logging_exporter"
+	lte, err := NewTraceExporter(exporterName, zap.NewNop())
 	if err != nil {
 		t.Fatalf("Wanted nil got %v", err)
 	}
@@ -34,13 +35,14 @@ func TestLoggingTraceExporterNoErrors(t *testing.T) {
 	if err := lte.ConsumeTraceData(context.Background(), td); err != nil {
 		t.Fatalf("Wanted nil got %v", err)
 	}
-	if lte.TraceExportFormat() != "logging_trace" {
-		t.Errorf("Wanted logging_trace got %v", lte.TraceExportFormat())
+	if lte.TraceExporterName() != exporterName {
+		t.Errorf("Wanted %q got %q", exporterName, lte.TraceExporterName())
 	}
 }
 
 func TestLoggingMetricsExporterNoErrors(t *testing.T) {
-	lme, err := NewMetricsExporter(zap.NewNop())
+	const exporterName = "test_metrics_exporter"
+	lme, err := NewMetricsExporter(exporterName, zap.NewNop())
 	if err != nil {
 		t.Fatalf("Wanted nil got %v", err)
 	}
@@ -50,7 +52,7 @@ func TestLoggingMetricsExporterNoErrors(t *testing.T) {
 	if err := lme.ConsumeMetricsData(context.Background(), md); err != nil {
 		t.Fatalf("Wanted nil got %v", err)
 	}
-	if lme.MetricsExportFormat() != "logging_metrics" {
-		t.Errorf("Wanted logging_metrics got %v", lme.MetricsExportFormat())
+	if lme.MetricsExporterName() != exporterName {
+		t.Errorf("Wanted %q got %q", exporterName, lme.MetricsExporterName())
 	}
 }

--- a/receiver/end_to_end_test.go
+++ b/receiver/end_to_end_test.go
@@ -19,21 +19,20 @@ import (
 	"log"
 	"time"
 
-	"github.com/open-telemetry/opentelemetry-service/exporter/loggingexporter"
-
 	"contrib.go.opencensus.io/exporter/ocagent"
 	"go.opencensus.io/trace"
+	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-service/exporter/loggingexporter"
 	"github.com/open-telemetry/opentelemetry-service/receiver"
 	"github.com/open-telemetry/opentelemetry-service/receiver/opencensusreceiver"
-	"go.uber.org/zap"
 )
 
 func Example_endToEnd() {
 	// This is what the cmd/ocagent code would look like this.
 	// A trace receiver as per the trace receiver
 	// configs that have been parsed.
-	lte, err := loggingexporter.NewTraceExporter(zap.NewNop())
+	lte, err := loggingexporter.NewTraceExporter("logging_exporter", zap.NewNop())
 	if err != nil {
 		log.Fatalf("Failed to create logging exporter: %v", err)
 	}


### PR DESCRIPTION
Continuing the refactor that started from exporterhelper in proper naming the related fileds and methods.

Continuation of #220 (see [comment](https://github.com/open-telemetry/opentelemetry-service/pull/220#discussion_r309932153))