### PR TITLE
Fix nil pointer panic whens stopping exporters

### DIFF
--- a/service/builder/exporters_builder.go
+++ b/service/builder/exporters_builder.go
@@ -172,6 +172,7 @@ func (eb *ExportersBuilder) buildExporter(
 		// if there are no pipelines associated with the exporter.
 		eb.logger.Warn("Exporter " + config.Name() +
 			" is not associated with any pipeline and will not export data.")
+		exporter.stop = func() error { return nil }
 		return exporter, nil
 	}
 

--- a/service/builder/exporters_builder_test.go
+++ b/service/builder/exporters_builder_test.go
@@ -88,7 +88,7 @@ func TestExportersBuilder_Build(t *testing.T) {
 	require.NotNil(t, e1)
 	assert.Nil(t, e1.tc)
 	assert.Nil(t, e1.mc)
-	assert.Nil(t, e1.stop)
+	assert.NotNil(t, e1.stop)
 
 	// TODO: once we have an exporter that supports metrics data type test it too.
 }


### PR DESCRIPTION
- Exporters not used in any pipeline cause panic during shutting
  down.

Signed-off-by: Hui Kang <kangh@us.ibm.com>