### PR TITLE
Refactor common errors to oterr/constants.go

### DIFF
--- a/oterr/constants.go
+++ b/oterr/constants.go
@@ -1,0 +1,32 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oterr
+
+import (
+	"errors"
+)
+
+var (
+	// ErrAlreadyStarted indicates an error on starting an already-started
+	// receiver/processor/exporter.
+	ErrAlreadyStarted = errors.New("already started")
+
+	// ErrAlreadyStopped indicates an error on stoping an already-stopped
+	// receiver/processor/exporter.
+	ErrAlreadyStopped = errors.New("already stopped")
+
+	// ErrNilNextConsumer indicates an error on nil next consumer.
+	ErrNilNextConsumer = errors.New("nil nextConsumer")
+)

--- a/processor/addattributesprocessor/addattributesprocessor.go
+++ b/processor/addattributesprocessor/addattributesprocessor.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
 	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-service/oterr"
 	"github.com/open-telemetry/opentelemetry-service/processor"
 )
 
@@ -80,6 +81,9 @@ var _ processor.TraceProcessor = (*addattributesprocessor)(nil)
 // NewTraceProcessor returns a processor.TraceProcessor that adds the WithAttributeMap(attributes) to all spans
 // passed to it. If a key already exists, we will only overwrite is the WithOverwrite(true) is set.
 func NewTraceProcessor(nextConsumer consumer.TraceConsumer, options ...Option) (processor.TraceProcessor, error) {
+	if nextConsumer == nil {
+		return nil, oterr.ErrNilNextConsumer
+	}
 	aap := &addattributesprocessor{nextConsumer: nextConsumer}
 	for _, opt := range options {
 		if err := opt(aap); err != nil {

--- a/processor/addattributesprocessor/factory_test.go
+++ b/processor/addattributesprocessor/factory_test.go
@@ -17,9 +17,10 @@ package addattributesprocessor
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -32,11 +33,20 @@ func TestCreateProcessor(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig()
 
-	tp, err := factory.CreateTraceProcessor(zap.NewNop(), nil, cfg)
+	tp, err := factory.CreateTraceProcessor(zap.NewNop(), exportertest.NewNopTraceExporter(), cfg)
 	assert.NotNil(t, tp)
 	assert.NoError(t, err, "cannot create trace processor")
 
-	mp, err := factory.CreateMetricsProcessor(zap.NewNop(), nil, cfg)
+	mp, err := factory.CreateMetricsProcessor(zap.NewNop(), exportertest.NewNopMetricsExporter(), cfg)
 	assert.Nil(t, mp)
 	assert.Error(t, err, "should not be able to create metric processor")
+}
+
+func TestNilConsumer(t *testing.T) {
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig()
+
+	tp, err := factory.CreateTraceProcessor(zap.NewNop(), nil, cfg)
+	assert.Nil(t, tp)
+	assert.Error(t, err, "expected to get a non-nil error")
 }

--- a/processor/attributekeyprocessor/attributekeyprocessor.go
+++ b/processor/attributekeyprocessor/attributekeyprocessor.go
@@ -16,11 +16,11 @@ package attributekeyprocessor
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
 	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-service/oterr"
 	"github.com/open-telemetry/opentelemetry-service/processor"
 )
 
@@ -49,7 +49,7 @@ var _ processor.TraceProcessor = (*attributekeyprocessor)(nil)
 // NewTraceProcessor returns a processor.TraceProcessor
 func NewTraceProcessor(nextConsumer consumer.TraceConsumer, replacements ...KeyReplacement) (processor.TraceProcessor, error) {
 	if nextConsumer == nil {
-		return nil, errors.New("nextConsumer is nil")
+		return nil, oterr.ErrNilNextConsumer
 	}
 
 	lenReplacements := len(replacements)

--- a/processor/probabilisticsampler/probabilisticsampler.go
+++ b/processor/probabilisticsampler/probabilisticsampler.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
 	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-service/oterr"
 	"github.com/open-telemetry/opentelemetry-service/processor"
 )
 
@@ -64,7 +65,7 @@ var _ processor.TraceProcessor = (*tracesamplerprocessor)(nil)
 // configuration.
 func NewTraceProcessor(nextConsumer consumer.TraceConsumer, cfg Config) (processor.TraceProcessor, error) {
 	if nextConsumer == nil {
-		return nil, errors.New("nextConsumer is nil")
+		return nil, oterr.ErrNilNextConsumer
 	}
 
 	return &tracesamplerprocessor{

--- a/processor/tailsampling/processor.go
+++ b/processor/tailsampling/processor.go
@@ -16,7 +16,6 @@ package tailsampling
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"runtime"
 	"sync"
@@ -31,6 +30,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/consumer"
 	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/observability"
+	"github.com/open-telemetry/opentelemetry-service/oterr"
 	"github.com/open-telemetry/opentelemetry-service/processor"
 	"github.com/open-telemetry/opentelemetry-service/processor/tailsampling/idbatcher"
 	"github.com/open-telemetry/opentelemetry-service/processor/tailsampling/sampling"
@@ -77,7 +77,7 @@ var _ processor.TraceProcessor = (*tailSamplingSpanProcessor)(nil)
 // configuration.
 func NewTraceProcessor(logger *zap.Logger, nextConsumer consumer.TraceConsumer, cfg Config) (processor.TraceProcessor, error) {
 	if nextConsumer == nil {
-		return nil, errors.New("nextConsumer is nil")
+		return nil, oterr.ErrNilNextConsumer
 	}
 
 	numDecisionBatches := uint64(cfg.DecisionWait.Seconds())

--- a/receiver/opencensusreceiver/ocmetrics/opencensus.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus.go
@@ -31,6 +31,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/consumer"
 	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/observability"
+	"github.com/open-telemetry/opentelemetry-service/oterr"
 )
 
 // Receiver is the type used to handle metrics from OpenCensus exporters.
@@ -43,7 +44,7 @@ type Receiver struct {
 // New creates a new ocmetrics.Receiver reference.
 func New(nextConsumer consumer.MetricsConsumer, opts ...Option) (*Receiver, error) {
 	if nextConsumer == nil {
-		return nil, errors.New("needs a non-nil consumer.MetricsConsumer")
+		return nil, oterr.ErrNilNextConsumer
 	}
 	ocr := &Receiver{nextConsumer: nextConsumer}
 	for _, opt := range opts {

--- a/receiver/opencensusreceiver/octrace/opencensus.go
+++ b/receiver/opencensusreceiver/octrace/opencensus.go
@@ -27,6 +27,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/consumer"
 	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/observability"
+	"github.com/open-telemetry/opentelemetry-service/oterr"
 )
 
 const (
@@ -51,7 +52,7 @@ type traceDataWithCtx struct {
 // New creates a new opencensus.Receiver reference.
 func New(nextConsumer consumer.TraceConsumer, opts ...Option) (*Receiver, error) {
 	if nextConsumer == nil {
-		return nil, errors.New("needs a non-nil consumer.TraceConsumer")
+		return nil, oterr.ErrNilNextConsumer
 	}
 
 	messageChan := make(chan *traceDataWithCtx, messageChannelSize)

--- a/receiver/prometheusreceiver/internal/ocastore.go
+++ b/receiver/prometheusreceiver/internal/ocastore.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
+	"github.com/open-telemetry/opentelemetry-service/oterr"
 )
 
 const (
@@ -36,7 +37,6 @@ const (
 )
 
 var idSeq int64
-var errAlreadyStop = errors.New("ocaStore already stopped")
 var noop = &noopAppender{}
 
 // OcaStore is an interface combines io.Closer and prometheus' scrape.Appendable
@@ -97,15 +97,15 @@ func (o *ocaStore) Close() error {
 type noopAppender struct{}
 
 func (*noopAppender) Add(l labels.Labels, t int64, v float64) (uint64, error) {
-	return 0, errAlreadyStop
+	return 0, oterr.ErrAlreadyStopped
 }
 
 func (*noopAppender) AddFast(l labels.Labels, ref uint64, t int64, v float64) error {
-	return errAlreadyStop
+	return oterr.ErrAlreadyStopped
 }
 
 func (*noopAppender) Commit() error {
-	return errAlreadyStop
+	return oterr.ErrAlreadyStopped
 }
 
 func (*noopAppender) Rollback() error {

--- a/receiver/vmmetricsreceiver/metrics_receiver.go
+++ b/receiver/vmmetricsreceiver/metrics_receiver.go
@@ -15,15 +15,10 @@
 package vmmetricsreceiver
 
 import (
-	"errors"
 	"sync"
 
+	"github.com/open-telemetry/opentelemetry-service/oterr"
 	"github.com/open-telemetry/opentelemetry-service/receiver"
-)
-
-var (
-	errAlreadyStarted = errors.New("already started")
-	errAlreadyStopped = errors.New("already stopped")
 )
 
 var _ receiver.MetricsReceiver = (*Receiver)(nil)
@@ -50,7 +45,7 @@ func (vmr *Receiver) StartMetricsReception(host receiver.Host) error {
 	vmr.mu.Lock()
 	defer vmr.mu.Unlock()
 
-	var err = errAlreadyStarted
+	var err = oterr.ErrAlreadyStarted
 	vmr.startOnce.Do(func() {
 		vmr.vmc.StartCollection()
 		err = nil
@@ -63,7 +58,7 @@ func (vmr *Receiver) StopMetricsReception() error {
 	vmr.mu.Lock()
 	defer vmr.mu.Unlock()
 
-	var err = errAlreadyStopped
+	var err = oterr.ErrAlreadyStopped
 	vmr.stopOnce.Do(func() {
 		vmr.vmc.StopCollection()
 		err = nil

--- a/receiver/zipkinreceiver/trace_receiver.go
+++ b/receiver/zipkinreceiver/trace_receiver.go
@@ -40,15 +40,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/internal"
 	"github.com/open-telemetry/opentelemetry-service/observability"
+	"github.com/open-telemetry/opentelemetry-service/oterr"
 	"github.com/open-telemetry/opentelemetry-service/receiver"
 	tracetranslator "github.com/open-telemetry/opentelemetry-service/translator/trace"
 	zipkintranslator "github.com/open-telemetry/opentelemetry-service/translator/trace/zipkin"
-)
-
-var (
-	errNilNextConsumer = errors.New("nil nextConsumer")
-	errAlreadyStarted  = errors.New("already started")
-	errAlreadyStopped  = errors.New("already stopped")
 )
 
 // ZipkinReceiver type is used to handle spans received in the Zipkin format.
@@ -72,7 +67,7 @@ var _ http.Handler = (*ZipkinReceiver)(nil)
 // New creates a new zipkinreceiver.ZipkinReceiver reference.
 func New(address string, nextConsumer consumer.TraceConsumer) (*ZipkinReceiver, error) {
 	if nextConsumer == nil {
-		return nil, errNilNextConsumer
+		return nil, oterr.ErrNilNextConsumer
 	}
 
 	zr := &ZipkinReceiver{
@@ -108,7 +103,7 @@ func (zr *ZipkinReceiver) StartTraceReception(host receiver.Host) error {
 	zr.mu.Lock()
 	defer zr.mu.Unlock()
 
-	var err = errAlreadyStarted
+	var err = oterr.ErrAlreadyStarted
 
 	zr.startOnce.Do(func() {
 		ln, lerr := net.Listen("tcp", zr.address())
@@ -239,7 +234,7 @@ func (zr *ZipkinReceiver) deserializeFromJSON(jsonBlob []byte, debugWasSet bool)
 // giving it a chance to perform any necessary clean-up and shutting down
 // its HTTP server.
 func (zr *ZipkinReceiver) StopTraceReception() error {
-	var err = errAlreadyStopped
+	var err = oterr.ErrAlreadyStopped
 	zr.stopOnce.Do(func() {
 		err = zr.server.Close()
 	})

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-service/internal"
 	"github.com/open-telemetry/opentelemetry-service/internal/testutils"
+	"github.com/open-telemetry/opentelemetry-service/oterr"
 	"github.com/open-telemetry/opentelemetry-service/receiver"
 	"github.com/open-telemetry/opentelemetry-service/receiver/receivertest"
 	spandatatranslator "github.com/open-telemetry/opentelemetry-service/translator/trace/spandata"
@@ -126,7 +127,7 @@ func TestNew(t *testing.T) {
 		{
 			name:    "nil nextConsumer",
 			args:    args{},
-			wantErr: errNilNextConsumer,
+			wantErr: oterr.ErrNilNextConsumer,
 		},
 		{
 			name: "happy path",

--- a/receiver/zipkinreceiver/zipkinscribereceiver/scribe_receiver_test.go
+++ b/receiver/zipkinreceiver/zipkinscribereceiver/scribe_receiver_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/consumer"
 	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exportertest"
+	"github.com/open-telemetry/opentelemetry-service/oterr"
 )
 
 func TestNewReceiver(t *testing.T) {
@@ -51,7 +52,7 @@ func TestNewReceiver(t *testing.T) {
 				port:     0,
 				category: "any",
 			},
-			wantErr: errNilNextConsumer,
+			wantErr: oterr.ErrNilNextConsumer,
 		},
 		{
 			name: "happy path",


### PR DESCRIPTION
To avoid re-declaring the same error in multiple packages.