### PR TITLE
Jaeger Receiver Documentation

### DIFF
--- a/receiver/README.md
+++ b/receiver/README.md
@@ -95,21 +95,31 @@ receivers:
 
 ## <a name="jaeger"></a>Jaeger Receiver
 **Only traces are supported.**
-// TODO(ccaraman) Update Jaeger receiver documentation.
 
-This receiver receives spans from Jaeger collector HTTP and Thrift uploads and translates them into the internal span types that are then sent to the collector/exporters.
-Only traces are supported. This receiver does not support metrics.
+This receiver receives traces from [Jaeger](https://www.jaegertracing.io)
+instrumented applications. It translates them into the internal format and sends
+it to processors and receivers.
 
-Its address can be configured in the YAML configuration file under section "receivers", subsection "jaeger" and fields "collector_http_port", "collector_thrift_port".
+It supports multiple protocols:
+- Thrift HTTP
+- Thrift TChannel
+- gRPC
 
-For example:
-
+By default, the Jaeger receiver supports all three protocols on the default ports
+specified in [factory.go](jaegerreceiver/factory.go). The following demonstrates
+how to specify the default Jaeger receiver.
 ```yaml
 receivers:
-  jaeger:
-    collector_thrift_port: 14267
-    collector_http_port: 14268
+  jaegers:
 ```
+
+It is possible to configure the protocols on different ports, refer to
+[config.yaml](jaegerreceiver/testdata/config.yaml) for detailed config
+examples.
+
+// TODO Issue https://github.com/open-telemetry/opentelemetry-service/issues/158
+// The Jaeger receiver enables all protocols even when one is specified or a
+// subset is enabled. The documentation should be updated when that fix occurs.
 
 ## <a name="prometheus"></a>Prometheus Receiver
 **Only metrics are supported.**

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -96,9 +96,9 @@ receivers:
 ## <a name="jaeger"></a>Jaeger Receiver
 **Only traces are supported.**
 
-This receiver receives traces from [Jaeger](https://www.jaegertracing.io)
-instrumented applications. It translates them into the internal format and sends
-it to processors and receivers.
+This receiver receives traces in the [Jaeger](https://www.jaegertracing.io)
+format. It translates them into the internal format and sends
+it to processors and exporters.
 
 It supports multiple protocols:
 - Thrift HTTP
@@ -110,7 +110,7 @@ specified in [factory.go](jaegerreceiver/factory.go). The following demonstrates
 how to specify the default Jaeger receiver.
 ```yaml
 receivers:
-  jaegers:
+  jaeger:
 ```
 
 It is possible to configure the protocols on different ports, refer to

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -55,7 +55,7 @@ func TestLoadConfig(t *testing.T) {
 					Endpoint: "127.0.0.1:9876",
 				},
 				"thrift-http": {
-					Endpoint: "127.0.0.1:3456",
+					Endpoint: ":3456",
 				},
 				"thrift-tchannel": {
 					Endpoint: "0.0.0.0:123",

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -38,6 +38,8 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
+	// The receiver `jaeger/disabled` doesn't count because disabled receivers
+	// are excluded from the final list.
 	assert.Equal(t, len(cfg.Receivers), 2)
 
 	r0 := cfg.Receivers["jaeger"]
@@ -50,11 +52,9 @@ func TestLoadConfig(t *testing.T) {
 			NameVal: "jaeger/customname",
 			Protocols: map[string]*configmodels.ReceiverSettings{
 				"grpc": {
-					Disabled: true,
 					Endpoint: "127.0.0.1:9876",
 				},
 				"thrift-http": {
-					Disabled: true,
 					Endpoint: "127.0.0.1:3456",
 				},
 				"thrift-tchannel": {

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -35,8 +35,10 @@ const (
 	typeStr = "jaeger"
 
 	// Protocol values.
-	protoGRPC           = "grpc"
-	protoThriftHTTP     = "thrift-http"
+	protoGRPC       = "grpc"
+	protoThriftHTTP = "thrift-http"
+	// TODO https://github.com/open-telemetry/opentelemetry-service/issues/267
+	//	Remove ThriftTChannel support.
 	protoThriftTChannel = "thrift-tchannel"
 
 	// Default endpoints to bind to.

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -1,15 +1,36 @@
 receivers:
+  # The following demonstrates initializing the default jaeger receiver.
+  # By default all three protocols (grpc, thrift-http, thrift-tchannel)
+  # are enabled and the default endpoints are specified in factory.go
   jaeger:
+  # The following demonstrates specifying different ports.
+  # The Jaeger receiver only connects to ports and ignores addresses.
+  # However, an address is needed to specify for a proper configuration.
+  # Ex: `endpoint: "9876"` is incorrect
+  # Ex: `endpoint: "1.2.3.4:9876"` is correct
   jaeger/customname:
     protocols:
       grpc:
         endpoint: "127.0.0.1:9876"
-        disabled: true
       thrift-http:
         endpoint: "127.0.0.1:3456"
-        disabled: true
       thrift-tchannel:
         endpoint: "0.0.0.0:123"
+
+  # The following demonstrates disabling the receiver.
+  # All of the protocols need to be disabled for the receiver to be disabled.
+  # If only one protocol is disabled, that is ignored and the protocol is
+  # enabled.
+  # This is to be fixed with issue
+  # https://github.com/open-telemetry/opentelemetry-service/issues/158
+  jaeger/disabled:
+    protocols:
+      grpc:
+        disabled: true
+      thrift-http:
+        disabled: true
+      thrift-tchannel:
+        disabled: true
 
 processors:
   exampleprocessor:

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -3,24 +3,23 @@ receivers:
   # By default all three protocols (grpc, thrift-http, thrift-tchannel)
   # are enabled and the default endpoints are specified in factory.go
   jaeger:
-  # The following demonstrates specifying different ports.
-  # The Jaeger receiver only connects to ports and ignores addresses.
-  # However, an address is needed to specify for a proper configuration.
-  # Ex: `endpoint: "9876"` is incorrect
-  # Ex: `endpoint: "1.2.3.4:9876"` is correct
+  # The following demonstrates specifying different endpoints.
+  # The Jaeger receiver connects to ports on all available network interfaces.
+  # Ex: `endpoint: "9876"` is incorrect.
+  # Ex: `endpoint: "1.2.3.4:9876"`  and ":9876" is correct
   jaeger/customname:
     protocols:
       grpc:
         endpoint: "127.0.0.1:9876"
       thrift-http:
-        endpoint: "127.0.0.1:3456"
+        endpoint: ":3456"
       thrift-tchannel:
         endpoint: "0.0.0.0:123"
 
   # The following demonstrates disabling the receiver.
   # All of the protocols need to be disabled for the receiver to be disabled.
-  # If only one protocol is disabled, that is ignored and the protocol is
-  # enabled.
+  # If a subset of the protocols are disabled, the disabled flags are ignored
+  # and all protocols are enabled.
   # This is to be fixed with issue
   # https://github.com/open-telemetry/opentelemetry-service/issues/158
   jaeger/disabled:

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -134,6 +134,8 @@ func (jr *jReceiver) agentAddress() string {
 	return fmt.Sprintf(":%d", port)
 }
 
+// TODO https://github.com/open-telemetry/opentelemetry-service/issues/267
+//	Remove ThriftTChannel support.
 func (jr *jReceiver) tchannelAddr() string {
 	var port int
 	if jr.config != nil {


### PR DESCRIPTION
Updates the Jaeger receiver documentation in readme and config.yaml to detail default receiver, configure endpoints and disabling the entire receiver. 

Another round of documentation for Jaeger should be done when https://github.com/open-telemetry/opentelemetry-service/issues/158 is addressed.