### PR TITLE
Update observability tags,views,measures names

### DIFF
--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -91,7 +91,7 @@ func pushTraceDataWithMetrics(next PushTraceData) PushTraceData {
 		// TODO: Add retry logic here if we want to support because we need to record special metrics.
 		droppedSpans, err := next(ctx, td)
 		// TODO: How to record the reason of dropping?
-		observability.RecordTraceExporterMetrics(ctx, len(td.Spans), droppedSpans)
+		observability.RecordMetricsForTraceExporter(ctx, len(td.Spans), droppedSpans)
 		return droppedSpans, err
 	}
 }

--- a/exporter/zipkinexporter/zipkin.go
+++ b/exporter/zipkinexporter/zipkin.go
@@ -216,7 +216,7 @@ func (ze *zipkinExporter) ConsumeTraceData(ctx context.Context, td consumerdata.
 	}
 
 	// And finally record metrics on the number of exported spans.
-	observability.RecordTraceExporterMetrics(observability.ContextWithExporterName(ctx, "zipkin"), len(td.Spans), len(td.Spans)-goodSpans)
+	observability.RecordMetricsForTraceExporter(observability.ContextWithExporterName(ctx, "zipkin"), len(td.Spans), len(td.Spans)-goodSpans)
 
 	return nil
 }

--- a/observability/observability.go
+++ b/observability/observability.go
@@ -31,18 +31,18 @@ import (
 )
 
 var (
-	mReceiverReceivedSpans = stats.Int64("oc.io/receiver/received_spans", "Counts the number of spans received by the receiver", "1")
-	mReceiverDroppedSpans  = stats.Int64("oc.io/receiver/dropped_spans", "Counts the number of spans dropped by the receiver", "1")
+	mReceiverReceivedSpans = stats.Int64("otelsvc/receiver/received_spans", "Counts the number of spans received by the receiver", "1")
+	mReceiverDroppedSpans  = stats.Int64("otelsvc/receiver/dropped_spans", "Counts the number of spans dropped by the receiver", "1")
 
-	mExporterReceivedSpans = stats.Int64("oc.io/exporter/received_spans", "Counts the number of spans received by the exporter", "1")
-	mExporterDroppedSpans  = stats.Int64("oc.io/exporter/dropped_spans", "Counts the number of spans received by the exporter", "1")
+	mExporterReceivedSpans = stats.Int64("otelsvc/exporter/received_spans", "Counts the number of spans received by the exporter", "1")
+	mExporterDroppedSpans  = stats.Int64("otelsvc/exporter/dropped_spans", "Counts the number of spans received by the exporter", "1")
 )
 
 // TagKeyReceiver defines tag key for Receiver.
-var TagKeyReceiver, _ = tag.NewKey("oc_receiver")
+var TagKeyReceiver, _ = tag.NewKey("otelsvc_receiver")
 
 // TagKeyExporter defines tag key for Exporter.
-var TagKeyExporter, _ = tag.NewKey("oc_exporter")
+var TagKeyExporter, _ = tag.NewKey("otelsvc_exporter")
 
 // ViewReceiverReceivedSpans defines the view for the receiver received spans metric.
 var ViewReceiverReceivedSpans = &view.View{
@@ -88,31 +88,31 @@ var AllViews = []*view.View{
 	ViewExporterDroppedSpans,
 }
 
-// ContextWithReceiverName adds the tag "oc_receiver" and the name of the receiver as the value,
+// ContextWithReceiverName adds the tag "otelsvc_receiver" and the name of the receiver as the value,
 // and returns the newly created context. For receivers that can receive multiple signals it is
 // recommended to encode the signal as suffix (e.g. "oc_trace" and "oc_metrics").
 func ContextWithReceiverName(ctx context.Context, receiverName string) context.Context {
-	ctx, _ = tag.New(ctx, tag.Upsert(TagKeyReceiver, receiverName))
+	ctx, _ = tag.New(ctx, tag.Upsert(TagKeyReceiver, receiverName, tag.WithTTL(tag.TTLNoPropagation)))
 	return ctx
 }
 
-// RecordTraceReceiverMetrics records the number of the spans received and dropped by the receiver.
+// RecordMetricsForTraceReceiver records the number of the spans received and dropped by the receiver.
 // Use it with a context.Context generated using ContextWithReceiverName().
-func RecordTraceReceiverMetrics(ctxWithTraceReceiverName context.Context, receivedSpans int, droppedSpans int) {
+func RecordMetricsForTraceReceiver(ctxWithTraceReceiverName context.Context, receivedSpans int, droppedSpans int) {
 	stats.Record(ctxWithTraceReceiverName, mReceiverReceivedSpans.M(int64(receivedSpans)), mReceiverDroppedSpans.M(int64(droppedSpans)))
 }
 
-// ContextWithExporterName adds the tag "oc_exporter" and the name of the exporter as the value,
+// ContextWithExporterName adds the tag "otelsvc_exporter" and the name of the exporter as the value,
 // and returns the newly created context. For exporters that can export multiple signals it is
 // recommended to encode the signal as suffix (e.g. "oc_trace" and "oc_metrics").
 func ContextWithExporterName(ctx context.Context, exporterName string) context.Context {
-	ctx, _ = tag.New(ctx, tag.Upsert(TagKeyExporter, exporterName))
+	ctx, _ = tag.New(ctx, tag.Upsert(TagKeyExporter, exporterName, tag.WithTTL(tag.TTLNoPropagation)))
 	return ctx
 }
 
-// RecordTraceExporterMetrics records the number of the spans received and dropped by the exporter.
+// RecordMetricsForTraceExporter records the number of the spans received and dropped by the exporter.
 // Use it with a context.Context generated using ContextWithExporterName().
-func RecordTraceExporterMetrics(ctx context.Context, receivedSpans int, droppedSpans int) {
+func RecordMetricsForTraceExporter(ctx context.Context, receivedSpans int, droppedSpans int) {
 	stats.Record(ctx, mExporterReceivedSpans.M(int64(receivedSpans)), mExporterDroppedSpans.M(int64(droppedSpans)))
 }
 

--- a/observability/observability_test.go
+++ b/observability/observability_test.go
@@ -34,9 +34,9 @@ func TestTracePieplineRecordedMetrics(t *testing.T) {
 	defer doneFn()
 
 	receiverCtx := observability.ContextWithReceiverName(context.Background(), receiverName)
-	observability.RecordTraceReceiverMetrics(receiverCtx, 17, 13)
+	observability.RecordMetricsForTraceReceiver(receiverCtx, 17, 13)
 	exporterCtx := observability.ContextWithExporterName(receiverCtx, exporterName)
-	observability.RecordTraceExporterMetrics(exporterCtx, 27, 23)
+	observability.RecordMetricsForTraceExporter(exporterCtx, 27, 23)
 	if err := observabilitytest.CheckValueViewReceiverReceivedSpans(receiverName, 17); err != nil {
 		t.Fatalf("When check recorded values: want nil got %v", err)
 	}

--- a/observability/observabilitytest/observabilitytest_test.go
+++ b/observability/observabilitytest/observabilitytest_test.go
@@ -34,7 +34,7 @@ func TestCheckValueViewReceiverViews(t *testing.T) {
 	defer doneFn()
 
 	receiverCtx := observability.ContextWithReceiverName(context.Background(), receiverName)
-	observability.RecordTraceReceiverMetrics(receiverCtx, 17, 13)
+	observability.RecordMetricsForTraceReceiver(receiverCtx, 17, 13)
 	// Test expected values.
 	if err := observabilitytest.CheckValueViewReceiverReceivedSpans(receiverName, 17); err != nil {
 		t.Fatalf("When check recorded values: want nil got %v", err)
@@ -64,7 +64,7 @@ func TestCheckValueViewExporterViews(t *testing.T) {
 
 	receiverCtx := observability.ContextWithReceiverName(context.Background(), receiverName)
 	exporterCtx := observability.ContextWithExporterName(receiverCtx, exporterName)
-	observability.RecordTraceExporterMetrics(exporterCtx, 17, 13)
+	observability.RecordMetricsForTraceExporter(exporterCtx, 17, 13)
 	// Test expected values.
 	if err := observabilitytest.CheckValueViewExporterReceivedSpans(receiverName, exporterName, 17); err != nil {
 		t.Fatalf("When check recorded values: want nil got %v", err)
@@ -90,7 +90,7 @@ func TestCheckValueViewExporterViews(t *testing.T) {
 
 func TestNoSetupCalled(t *testing.T) {
 	receiverCtx := observability.ContextWithReceiverName(context.Background(), receiverName)
-	observability.RecordTraceReceiverMetrics(receiverCtx, 17, 13)
+	observability.RecordMetricsForTraceReceiver(receiverCtx, 17, 13)
 	// Failed to check because views are not registered.
 	if err := observabilitytest.CheckValueViewReceiverReceivedSpans(receiverName, 17); err == nil {
 		t.Fatalf("When check recorded values: want not-nil got nil")

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -267,7 +267,7 @@ func (jr *jReceiver) SubmitBatches(ctx thrift.Context, batches []*jaeger.Batch) 
 			td.SourceFormat = "jaeger"
 			jr.nextConsumer.ConsumeTraceData(ctx, td)
 			// We MUST unconditionally record metrics from this reception.
-			observability.RecordTraceReceiverMetrics(ctxWithReceiverName, len(batch.Spans), len(batch.Spans)-len(td.Spans))
+			observability.RecordMetricsForTraceReceiver(ctxWithReceiverName, len(batch.Spans), len(batch.Spans)-len(td.Spans))
 		}
 
 		jbsr = append(jbsr, &jaeger.BatchSubmitResponse{
@@ -292,12 +292,12 @@ func (jr *jReceiver) EmitZipkinBatch(spans []*zipkincore.Span) error {
 func (jr *jReceiver) EmitBatch(batch *jaeger.Batch) error {
 	td, err := jaegertranslator.ThriftBatchToOCProto(batch)
 	if err != nil {
-		observability.RecordTraceReceiverMetrics(jr.defaultAgentCtx, len(batch.Spans), len(batch.Spans))
+		observability.RecordMetricsForTraceReceiver(jr.defaultAgentCtx, len(batch.Spans), len(batch.Spans))
 		return err
 	}
 
 	err = jr.nextConsumer.ConsumeTraceData(jr.defaultAgentCtx, td)
-	observability.RecordTraceReceiverMetrics(jr.defaultAgentCtx, len(batch.Spans), len(batch.Spans)-len(td.Spans))
+	observability.RecordMetricsForTraceReceiver(jr.defaultAgentCtx, len(batch.Spans), len(batch.Spans)-len(td.Spans))
 
 	return err
 }
@@ -324,12 +324,12 @@ func (jr *jReceiver) PostSpans(ctx context.Context, r *api_v2.PostSpansRequest) 
 	td, err := jaegertranslator.ProtoBatchToOCProto(r.Batch)
 	td.SourceFormat = "jaeger"
 	if err != nil {
-		observability.RecordTraceReceiverMetrics(ctxWithReceiverName, len(r.Batch.Spans), len(r.Batch.Spans))
+		observability.RecordMetricsForTraceReceiver(ctxWithReceiverName, len(r.Batch.Spans), len(r.Batch.Spans))
 		return nil, err
 	}
 
 	err = jr.nextConsumer.ConsumeTraceData(ctx, td)
-	observability.RecordTraceReceiverMetrics(ctxWithReceiverName, len(r.Batch.Spans), len(r.Batch.Spans)-len(td.Spans))
+	observability.RecordMetricsForTraceReceiver(ctxWithReceiverName, len(r.Batch.Spans), len(r.Batch.Spans)-len(td.Spans))
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/opencensusreceiver/octrace/opencensus.go
+++ b/receiver/opencensusreceiver/octrace/opencensus.go
@@ -132,7 +132,7 @@ func (ocr *Receiver) Export(tes agenttracepb.TraceService_ExportServer) error {
 
 		ocr.messageChan <- &traceDataWithCtx{data: td, ctx: ctxWithReceiverName}
 
-		observability.RecordTraceReceiverMetrics(ctxWithReceiverName, len(td.Spans), 0)
+		observability.RecordMetricsForTraceReceiver(ctxWithReceiverName, len(td.Spans), 0)
 
 		recv, err = tes.Recv()
 		if err != nil {

--- a/receiver/zipkinreceiver/trace_receiver.go
+++ b/receiver/zipkinreceiver/trace_receiver.go
@@ -337,7 +337,7 @@ func (zr *ZipkinReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO: Get the number of dropped spans from the conversion failure.
-	observability.RecordTraceReceiverMetrics(ctxWithReceiverName, tdsSize, 0)
+	observability.RecordMetricsForTraceReceiver(ctxWithReceiverName, tdsSize, 0)
 
 	// Finally send back the response "Accepted" as
 	// required at https://zipkin.io/zipkin-api/#/default/post_spans


### PR DESCRIPTION
Change all agent tag's TTL to TTLNoPropagation to not propagate them to the next agent/collector/backend.

This PR changes:
1) If the default views are used for receiver/exporter metrics the metric name.
2) The label keys for all the views that are using the receiver/exporter metrics.