### PR TITLE
Add support to record metrics for metricsexporter

### DIFF
--- a/exporter/exporterhelper/constants.go
+++ b/exporter/exporterhelper/constants.go
@@ -28,8 +28,8 @@ var (
 )
 
 const (
-	numDroppedMetricsAttribute  = "num_dropped_metrics"
-	numReceivedMetricsAttribute = "num_received_metrics"
-	numDroppedSpansAttribute    = "num_dropped_spans"
-	numReceivedSpansAttribute   = "num_received_spans"
+	numDroppedTimeSeriesAttribute  = "num_dropped_timeseries"
+	numReceivedTimeSeriesAttribute = "num_received_timeseries"
+	numDroppedSpansAttribute       = "num_dropped_spans"
+	numReceivedSpansAttribute      = "num_received_spans"
 )

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -53,7 +53,6 @@ func (me *metricsExporter) Shutdown() error {
 
 // NewMetricsExporter creates an MetricsExporter that can record metrics and can wrap every request with a Span.
 // If no options are passed it just adds the exporter format as a tag in the Context.
-// TODO: Add support for recordMetrics.
 // TODO: Add support for retries.
 func NewMetricsExporter(exporterName string, pushMetricsData PushMetricsData, options ...ExporterOption) (exporter.MetricsExporter, error) {
 	if exporterName == "" {

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -90,7 +90,7 @@ func pushMetricsDataWithMetrics(next PushMetricsData) PushMetricsData {
 		// TODO: Add retry logic here if we want to support because we need to record special metrics.
 		droppedTimeSeries, err := next(ctx, md)
 		// TODO: How to record the reason of dropping?
-		observability.RecordMetricsForMetricsExporter(ctx, numTimeSeries(md), droppedTimeSeries)
+		observability.RecordMetricsForMetricsExporter(ctx, NumTimeSeries(md), droppedTimeSeries)
 		return droppedTimeSeries, err
 	}
 }
@@ -102,7 +102,7 @@ func pushMetricsDataWithSpan(next PushMetricsData, spanName string) PushMetricsD
 		// Call next stage.
 		droppedTimeSeries, err := next(ctx, md)
 		if span.IsRecordingEvents() {
-			receivedTimeSeries := numTimeSeries(md)
+			receivedTimeSeries := NumTimeSeries(md)
 			span.AddAttributes(
 				trace.Int64Attribute(numReceivedTimeSeriesAttribute, int64(receivedTimeSeries)),
 				trace.Int64Attribute(numDroppedTimeSeriesAttribute, int64(droppedTimeSeries)),
@@ -115,7 +115,8 @@ func pushMetricsDataWithSpan(next PushMetricsData, spanName string) PushMetricsD
 	}
 }
 
-func numTimeSeries(md consumerdata.MetricsData) int {
+// NumTimeSeries returns the number of timeseries in a MetricsData.
+func NumTimeSeries(md consumerdata.MetricsData) int {
 	receivedTimeSeries := 0
 	for _, metric := range md.Metrics {
 		receivedTimeSeries += len(metric.GetTimeseries())

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-service/exporter"
+	"github.com/open-telemetry/opentelemetry-service/observability"
+	"github.com/open-telemetry/opentelemetry-service/observability/observabilitytest"
 )
 
 func TestMetricsExporter_InvalidName(t *testing.T) {
@@ -55,32 +57,57 @@ func TestMetricsExporter_Default(t *testing.T) {
 func TestMetricsExporter_Default_ReturnError(t *testing.T) {
 	td := consumerdata.MetricsData{}
 	want := errors.New("my_error")
-	te, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, want))
+	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, want))
 	require.Nil(t, err)
-	require.NotNil(t, te)
-	require.Equal(t, want, te.ConsumeMetricsData(context.Background(), td))
+	require.NotNil(t, me)
+	require.Equal(t, want, me.ConsumeMetricsData(context.Background(), td))
+}
+
+func TestMetricsExporter_WithRecordMetrics(t *testing.T) {
+	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, nil), WithRecordMetrics(true))
+	require.Nil(t, err)
+	require.NotNil(t, me)
+
+	checkRecordedMetricsForMetricsExporter(t, me, nil, 0)
+}
+
+func TestMetricsExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
+	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(1, nil), WithRecordMetrics(true))
+	require.Nil(t, err)
+	require.NotNil(t, me)
+
+	checkRecordedMetricsForMetricsExporter(t, me, nil, 1)
+}
+
+func TestMetricsExporter_WithRecordMetrics_ReturnError(t *testing.T) {
+	want := errors.New("my_error")
+	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, want), WithRecordMetrics(true))
+	require.Nil(t, err)
+	require.NotNil(t, me)
+
+	checkRecordedMetricsForMetricsExporter(t, me, want, 0)
 }
 
 func TestMetricsExporter_WithSpan(t *testing.T) {
-	te, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, nil), WithSpanName(fakeSpanName))
+	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, nil), WithSpanName(fakeSpanName))
 	require.Nil(t, err)
-	require.NotNil(t, te)
-	checkWrapSpanForMetricsExporter(t, te, nil, 0)
+	require.NotNil(t, me)
+	checkWrapSpanForMetricsExporter(t, me, nil, 0)
 }
 
 func TestMetricsExporter_WithSpan_NonZeroDropped(t *testing.T) {
-	te, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(1, nil), WithSpanName(fakeSpanName))
+	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(1, nil), WithSpanName(fakeSpanName))
 	require.Nil(t, err)
-	require.NotNil(t, te)
-	checkWrapSpanForMetricsExporter(t, te, nil, 1)
+	require.NotNil(t, me)
+	checkWrapSpanForMetricsExporter(t, me, nil, 1)
 }
 
 func TestMetricsExporter_WithSpan_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	te, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, want), WithSpanName(fakeSpanName))
+	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, want), WithSpanName(fakeSpanName))
 	require.Nil(t, err)
-	require.NotNil(t, te)
-	checkWrapSpanForMetricsExporter(t, te, want, 0)
+	require.NotNil(t, me)
+	checkWrapSpanForMetricsExporter(t, me, want, 0)
 }
 
 func TestMetricsExporter_WithShutdown(t *testing.T) {
@@ -106,28 +133,57 @@ func TestMetricsExporter_WithShutdown_ReturnError(t *testing.T) {
 	assert.Equal(t, me.Shutdown(), want)
 }
 
-func newPushMetricsData(droppedSpans int, retError error) PushMetricsData {
+func newPushMetricsData(droppedTimeSeries int, retError error) PushMetricsData {
 	return func(ctx context.Context, td consumerdata.MetricsData) (int, error) {
-		return droppedSpans, retError
+		return droppedTimeSeries, retError
 	}
 }
 
-func generateMetricsTraffic(t *testing.T, te exporter.MetricsExporter, numRequests int, wantError error) {
-	td := consumerdata.MetricsData{Metrics: make([]*metricspb.Metric, 1)}
+func checkRecordedMetricsForMetricsExporter(t *testing.T, me exporter.MetricsExporter, wantError error, droppedTimeSeries int) {
+	doneFn := observabilitytest.SetupRecordedMetricsTest()
+	defer doneFn()
+	metrics := []*metricspb.Metric{
+		{
+			Timeseries: make([]*metricspb.TimeSeries, 1),
+		},
+		{
+			Timeseries: make([]*metricspb.TimeSeries, 1),
+		},
+	}
+	md := consumerdata.MetricsData{Metrics: metrics}
+	ctx := observability.ContextWithReceiverName(context.Background(), fakeReceiverName)
+	const numBatches = 7
+	for i := 0; i < numBatches; i++ {
+		require.Equal(t, wantError, me.ConsumeMetricsData(ctx, md))
+	}
+
+	err := observabilitytest.CheckValueViewExporterReceivedTimeSeries(fakeReceiverName, me.Name(), numBatches*numTimeSeries(md))
+	require.Nilf(t, err, "CheckValueViewExporterTimeSeries: Want nil Got %v", err)
+
+	err = observabilitytest.CheckValueViewExporterDroppedTimeSeries(fakeReceiverName, me.Name(), numBatches*droppedTimeSeries)
+	require.Nilf(t, err, "CheckValueViewExporterTimeSeries: Want nil Got %v", err)
+}
+
+func generateMetricsTraffic(t *testing.T, me exporter.MetricsExporter, numRequests int, wantError error) {
+	md := consumerdata.MetricsData{Metrics: []*metricspb.Metric{
+		{
+			Timeseries: make([]*metricspb.TimeSeries, 1),
+		},
+	}}
 	ctx, span := trace.StartSpan(context.Background(), fakeParentSpanName, trace.WithSampler(trace.AlwaysSample()))
 	defer span.End()
 	for i := 0; i < numRequests; i++ {
-		require.Equal(t, wantError, te.ConsumeMetricsData(ctx, td))
+		require.Equal(t, wantError, me.ConsumeMetricsData(ctx, md))
 	}
 }
 
-func checkWrapSpanForMetricsExporter(t *testing.T, te exporter.MetricsExporter, wantError error, droppedSpans int) {
+func checkWrapSpanForMetricsExporter(t *testing.T, me exporter.MetricsExporter, wantError error, droppedSpans int) {
 	ocSpansSaver := new(testOCTraceExporter)
 	trace.RegisterExporter(ocSpansSaver)
 	defer trace.UnregisterExporter(ocSpansSaver)
 
 	const numRequests = 5
-	generateMetricsTraffic(t, te, numRequests, wantError)
+	generateMetricsTraffic(t, me, numRequests, wantError)
 
 	// Inspection time!
 	ocSpansSaver.mu.Lock()
@@ -144,7 +200,7 @@ func checkWrapSpanForMetricsExporter(t *testing.T, te exporter.MetricsExporter, 
 	for _, sd := range gotSpanData[:numRequests] {
 		require.Equalf(t, parentSpan.SpanContext.SpanID, sd.ParentSpanID, "Exporter span not a child\nSpanData %v", sd)
 		require.Equalf(t, errToStatus(wantError), sd.Status, "SpanData %v", sd)
-		require.Equalf(t, int64(1), sd.Attributes[numReceivedMetricsAttribute], "SpanData %v", sd)
-		require.Equalf(t, int64(droppedSpans), sd.Attributes[numDroppedMetricsAttribute], "SpanData %v", sd)
+		require.Equalf(t, int64(1), sd.Attributes[numReceivedTimeSeriesAttribute], "SpanData %v", sd)
+		require.Equalf(t, int64(droppedSpans), sd.Attributes[numDroppedTimeSeriesAttribute], "SpanData %v", sd)
 	}
 }

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -29,6 +29,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-service/observability/observabilitytest"
 )
 
+const (
+	fakeMetricsReceiverName = "fake_receiver"
+	fakeMetricsExporterName = "fake_exporter"
+)
+
 func TestMetricsExporter_InvalidName(t *testing.T) {
 	me, err := NewMetricsExporter("", newPushMetricsData(0, nil))
 	require.Nil(t, me)
@@ -36,35 +41,35 @@ func TestMetricsExporter_InvalidName(t *testing.T) {
 }
 
 func TestMetricsExporter_NilPushMetricsData(t *testing.T) {
-	me, err := NewMetricsExporter(fakeExporterName, nil)
+	me, err := NewMetricsExporter(fakeMetricsExporterName, nil)
 	require.Nil(t, me)
 	require.Equal(t, errNilPushMetricsData, err)
 }
 
 func TestMetricsExporter_Default(t *testing.T) {
 	md := consumerdata.MetricsData{}
-	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, nil))
+	me, err := NewMetricsExporter(fakeMetricsExporterName, newPushMetricsData(0, nil))
 	assert.NotNil(t, me)
 	assert.Nil(t, err)
 
 	assert.Nil(t, me.ConsumeMetricsData(context.Background(), md))
 
-	assert.Equal(t, me.Name(), fakeExporterName)
+	assert.Equal(t, me.Name(), fakeMetricsExporterName)
 
 	assert.Nil(t, me.Shutdown())
 }
 
 func TestMetricsExporter_Default_ReturnError(t *testing.T) {
-	td := consumerdata.MetricsData{}
+	md := consumerdata.MetricsData{}
 	want := errors.New("my_error")
-	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, want))
+	me, err := NewMetricsExporter(fakeMetricsExporterName, newPushMetricsData(0, want))
 	require.Nil(t, err)
 	require.NotNil(t, me)
-	require.Equal(t, want, me.ConsumeMetricsData(context.Background(), td))
+	require.Equal(t, want, me.ConsumeMetricsData(context.Background(), md))
 }
 
 func TestMetricsExporter_WithRecordMetrics(t *testing.T) {
-	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, nil), WithRecordMetrics(true))
+	me, err := NewMetricsExporter(fakeMetricsExporterName, newPushMetricsData(0, nil), WithRecordMetrics(true))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
@@ -72,7 +77,7 @@ func TestMetricsExporter_WithRecordMetrics(t *testing.T) {
 }
 
 func TestMetricsExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
-	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(1, nil), WithRecordMetrics(true))
+	me, err := NewMetricsExporter(fakeMetricsExporterName, newPushMetricsData(1, nil), WithRecordMetrics(true))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
@@ -81,7 +86,7 @@ func TestMetricsExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
 
 func TestMetricsExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, want), WithRecordMetrics(true))
+	me, err := NewMetricsExporter(fakeMetricsExporterName, newPushMetricsData(0, want), WithRecordMetrics(true))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
@@ -89,14 +94,14 @@ func TestMetricsExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 }
 
 func TestMetricsExporter_WithSpan(t *testing.T) {
-	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, nil), WithSpanName(fakeSpanName))
+	me, err := NewMetricsExporter(fakeMetricsExporterName, newPushMetricsData(0, nil), WithSpanName(fakeSpanName))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForMetricsExporter(t, me, nil, 0)
 }
 
 func TestMetricsExporter_WithSpan_NonZeroDropped(t *testing.T) {
-	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(1, nil), WithSpanName(fakeSpanName))
+	me, err := NewMetricsExporter(fakeMetricsExporterName, newPushMetricsData(1, nil), WithSpanName(fakeSpanName))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForMetricsExporter(t, me, nil, 1)
@@ -104,7 +109,7 @@ func TestMetricsExporter_WithSpan_NonZeroDropped(t *testing.T) {
 
 func TestMetricsExporter_WithSpan_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, want), WithSpanName(fakeSpanName))
+	me, err := NewMetricsExporter(fakeMetricsExporterName, newPushMetricsData(0, want), WithSpanName(fakeSpanName))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForMetricsExporter(t, me, want, 0)
@@ -114,7 +119,7 @@ func TestMetricsExporter_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func() error { shutdownCalled = true; return nil }
 
-	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, nil), WithShutdown(shutdown))
+	me, err := NewMetricsExporter(fakeMetricsExporterName, newPushMetricsData(0, nil), WithShutdown(shutdown))
 	assert.NotNil(t, me)
 	assert.Nil(t, err)
 
@@ -126,7 +131,7 @@ func TestMetricsExporter_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func() error { return want }
 
-	me, err := NewMetricsExporter(fakeExporterName, newPushMetricsData(0, nil), WithShutdown(shutdownErr))
+	me, err := NewMetricsExporter(fakeMetricsExporterName, newPushMetricsData(0, nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, me)
 	assert.Nil(t, err)
 
@@ -151,16 +156,16 @@ func checkRecordedMetricsForMetricsExporter(t *testing.T, me exporter.MetricsExp
 		},
 	}
 	md := consumerdata.MetricsData{Metrics: metrics}
-	ctx := observability.ContextWithReceiverName(context.Background(), fakeReceiverName)
+	ctx := observability.ContextWithReceiverName(context.Background(), fakeMetricsReceiverName)
 	const numBatches = 7
 	for i := 0; i < numBatches; i++ {
 		require.Equal(t, wantError, me.ConsumeMetricsData(ctx, md))
 	}
 
-	err := observabilitytest.CheckValueViewExporterReceivedTimeSeries(fakeReceiverName, me.Name(), numBatches*NumTimeSeries(md))
+	err := observabilitytest.CheckValueViewExporterReceivedTimeSeries(fakeMetricsReceiverName, me.Name(), numBatches*NumTimeSeries(md))
 	require.Nilf(t, err, "CheckValueViewExporterTimeSeries: Want nil Got %v", err)
 
-	err = observabilitytest.CheckValueViewExporterDroppedTimeSeries(fakeReceiverName, me.Name(), numBatches*droppedTimeSeries)
+	err = observabilitytest.CheckValueViewExporterDroppedTimeSeries(fakeMetricsReceiverName, me.Name(), numBatches*droppedTimeSeries)
 	require.Nilf(t, err, "CheckValueViewExporterTimeSeries: Want nil Got %v", err)
 }
 

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -157,7 +157,7 @@ func checkRecordedMetricsForMetricsExporter(t *testing.T, me exporter.MetricsExp
 		require.Equal(t, wantError, me.ConsumeMetricsData(ctx, md))
 	}
 
-	err := observabilitytest.CheckValueViewExporterReceivedTimeSeries(fakeReceiverName, me.Name(), numBatches*numTimeSeries(md))
+	err := observabilitytest.CheckValueViewExporterReceivedTimeSeries(fakeReceiverName, me.Name(), numBatches*NumTimeSeries(md))
 	require.Nilf(t, err, "CheckValueViewExporterTimeSeries: Want nil Got %v", err)
 
 	err = observabilitytest.CheckValueViewExporterDroppedTimeSeries(fakeReceiverName, me.Name(), numBatches*droppedTimeSeries)

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -31,10 +31,10 @@ import (
 )
 
 const (
-	fakeReceiverName   = "fake_receiver"
-	fakeExporterName   = "fake_exporter"
-	fakeSpanName       = "fake_span_name"
-	fakeParentSpanName = "fake_parent_span_name"
+	fakeTraceReceiverName = "fake_receiver"
+	fakeTraceExporterName = "fake_exporter"
+	fakeSpanName          = "fake_span_name"
+	fakeParentSpanName    = "fake_parent_span_name"
 )
 
 // TODO https://github.com/open-telemetry/opentelemetry-service/issues/266
@@ -46,26 +46,26 @@ func TestTraceExporter_InvalidName(t *testing.T) {
 }
 
 func TestTraceExporter_NilPushTraceData(t *testing.T) {
-	te, err := NewTraceExporter(fakeExporterName, nil)
+	te, err := NewTraceExporter(fakeTraceExporterName, nil)
 	require.Nil(t, te)
 	require.Equal(t, errNilPushTraceData, err)
 }
 
 func TestTraceExporter_Default(t *testing.T) {
 	td := consumerdata.TraceData{}
-	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, nil))
+	te, err := NewTraceExporter(fakeTraceExporterName, newPushTraceData(0, nil))
 	assert.NotNil(t, te)
 	assert.Nil(t, err)
 
 	assert.Nil(t, te.ConsumeTraceData(context.Background(), td))
-	assert.Equal(t, te.Name(), fakeExporterName)
+	assert.Equal(t, te.Name(), fakeTraceExporterName)
 	assert.Nil(t, te.Shutdown())
 }
 
 func TestTraceExporter_Default_ReturnError(t *testing.T) {
 	td := consumerdata.TraceData{}
 	want := errors.New("my_error")
-	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, want))
+	te, err := NewTraceExporter(fakeTraceExporterName, newPushTraceData(0, want))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -74,7 +74,7 @@ func TestTraceExporter_Default_ReturnError(t *testing.T) {
 }
 
 func TestTraceExporter_WithRecordMetrics(t *testing.T) {
-	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, nil), WithRecordMetrics(true))
+	te, err := NewTraceExporter(fakeTraceExporterName, newPushTraceData(0, nil), WithRecordMetrics(true))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -82,7 +82,7 @@ func TestTraceExporter_WithRecordMetrics(t *testing.T) {
 }
 
 func TestTraceExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
-	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(1, nil), WithRecordMetrics(true))
+	te, err := NewTraceExporter(fakeTraceExporterName, newPushTraceData(1, nil), WithRecordMetrics(true))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -91,7 +91,7 @@ func TestTraceExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
 
 func TestTraceExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, want), WithRecordMetrics(true))
+	te, err := NewTraceExporter(fakeTraceExporterName, newPushTraceData(0, want), WithRecordMetrics(true))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -99,7 +99,7 @@ func TestTraceExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 }
 
 func TestTraceExporter_WithSpan(t *testing.T) {
-	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, nil), WithSpanName(fakeSpanName))
+	te, err := NewTraceExporter(fakeTraceExporterName, newPushTraceData(0, nil), WithSpanName(fakeSpanName))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -107,7 +107,7 @@ func TestTraceExporter_WithSpan(t *testing.T) {
 }
 
 func TestTraceExporter_WithSpan_NonZeroDropped(t *testing.T) {
-	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(1, nil), WithSpanName(fakeSpanName))
+	te, err := NewTraceExporter(fakeTraceExporterName, newPushTraceData(1, nil), WithSpanName(fakeSpanName))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -116,7 +116,7 @@ func TestTraceExporter_WithSpan_NonZeroDropped(t *testing.T) {
 
 func TestTraceExporter_WithSpan_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, want), WithSpanName(fakeSpanName))
+	te, err := NewTraceExporter(fakeTraceExporterName, newPushTraceData(0, want), WithSpanName(fakeSpanName))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -127,7 +127,7 @@ func TestTraceExporter_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func() error { shutdownCalled = true; return nil }
 
-	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, nil), WithShutdown(shutdown))
+	te, err := NewTraceExporter(fakeTraceExporterName, newPushTraceData(0, nil), WithShutdown(shutdown))
 	assert.NotNil(t, te)
 	assert.Nil(t, err)
 
@@ -139,7 +139,7 @@ func TestTraceExporter_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func() error { return want }
 
-	te, err := NewTraceExporter(fakeExporterName, newPushTraceData(0, nil), WithShutdown(shutdownErr))
+	te, err := NewTraceExporter(fakeTraceExporterName, newPushTraceData(0, nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, te)
 	assert.Nil(t, err)
 
@@ -158,16 +158,16 @@ func checkRecordedMetricsForTraceExporter(t *testing.T, te exporter.TraceExporte
 
 	spans := make([]*tracepb.Span, 2)
 	td := consumerdata.TraceData{Spans: spans}
-	ctx := observability.ContextWithReceiverName(context.Background(), fakeReceiverName)
+	ctx := observability.ContextWithReceiverName(context.Background(), fakeTraceReceiverName)
 	const numBatches = 7
 	for i := 0; i < numBatches; i++ {
 		require.Equal(t, wantError, te.ConsumeTraceData(ctx, td))
 	}
 
-	err := observabilitytest.CheckValueViewExporterReceivedSpans(fakeReceiverName, te.Name(), numBatches*len(spans))
+	err := observabilitytest.CheckValueViewExporterReceivedSpans(fakeTraceReceiverName, te.Name(), numBatches*len(spans))
 	require.Nilf(t, err, "CheckValueViewExporterReceivedSpans: Want nil Got %v", err)
 
-	err = observabilitytest.CheckValueViewExporterDroppedSpans(fakeReceiverName, te.Name(), numBatches*droppedSpans)
+	err = observabilitytest.CheckValueViewExporterDroppedSpans(fakeTraceReceiverName, te.Name(), numBatches*droppedSpans)
 	require.Nilf(t, err, "CheckValueViewExporterDroppedSpans: Want nil Got %v", err)
 }
 

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -31,8 +31,8 @@ import (
 )
 
 const (
-	fakeReceiverName   = "fake_receiver_trace"
-	fakeExporterName   = "fake_exporter_trace"
+	fakeReceiverName   = "fake_receiver"
+	fakeExporterName   = "fake_exporter"
 	fakeSpanName       = "fake_span_name"
 	fakeParentSpanName = "fake_parent_span_name"
 )

--- a/exporter/opencensusexporter/opencensus.go
+++ b/exporter/opencensusexporter/opencensus.go
@@ -25,6 +25,7 @@ import (
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-service/exporter/exporterhelper"
 	"github.com/open-telemetry/opentelemetry-service/oterr"
 )
 
@@ -128,7 +129,7 @@ func (oce *ocagentExporter) PushMetricsData(ctx context.Context, md consumerdata
 			code: errAlreadyStopped,
 			msg:  fmt.Sprintf("OpenCensus exporter was already stopped."),
 		}
-		return numTimeSeries(md), err
+		return exporterhelper.NumTimeSeries(md), err
 	}
 
 	req := &agentmetricspb.ExportMetricsServiceRequest{
@@ -139,15 +140,7 @@ func (oce *ocagentExporter) PushMetricsData(ctx context.Context, md consumerdata
 	err := exporter.ExportMetricsServiceRequest(req)
 	oce.exporters <- exporter
 	if err != nil {
-		return numTimeSeries(md), err
+		return exporterhelper.NumTimeSeries(md), err
 	}
 	return 0, nil
-}
-
-func numTimeSeries(md consumerdata.MetricsData) int {
-	receivedTimeSeries := 0
-	for _, metric := range md.Metrics {
-		receivedTimeSeries += len(metric.GetTimeseries())
-	}
-	return receivedTimeSeries
 }

--- a/exporter/opencensusexporter/opencensus.go
+++ b/exporter/opencensusexporter/opencensus.go
@@ -128,7 +128,7 @@ func (oce *ocagentExporter) PushMetricsData(ctx context.Context, md consumerdata
 			code: errAlreadyStopped,
 			msg:  fmt.Sprintf("OpenCensus exporter was already stopped."),
 		}
-		return len(md.Metrics), err
+		return numTimeSeries(md), err
 	}
 
 	req := &agentmetricspb.ExportMetricsServiceRequest{
@@ -139,7 +139,15 @@ func (oce *ocagentExporter) PushMetricsData(ctx context.Context, md consumerdata
 	err := exporter.ExportMetricsServiceRequest(req)
 	oce.exporters <- exporter
 	if err != nil {
-		return len(md.Metrics), err
+		return numTimeSeries(md), err
 	}
 	return 0, nil
+}
+
+func numTimeSeries(md consumerdata.MetricsData) int {
+	receivedTimeSeries := 0
+	for _, metric := range md.Metrics {
+		receivedTimeSeries += len(metric.GetTimeseries())
+	}
+	return receivedTimeSeries
 }

--- a/observability/observability.go
+++ b/observability/observability.go
@@ -31,11 +31,15 @@ import (
 )
 
 var (
-	mReceiverReceivedSpans = stats.Int64("otelsvc/receiver/received_spans", "Counts the number of spans received by the receiver", "1")
-	mReceiverDroppedSpans  = stats.Int64("otelsvc/receiver/dropped_spans", "Counts the number of spans dropped by the receiver", "1")
+	mReceiverReceivedSpans      = stats.Int64("otelsvc/receiver/received_spans", "Counts the number of spans received by the receiver", "1")
+	mReceiverDroppedSpans       = stats.Int64("otelsvc/receiver/dropped_spans", "Counts the number of spans dropped by the receiver", "1")
+	mReceiverReceivedTimeSeries = stats.Int64("otelsvc/receiver/received_timeseries", "Counts the number of timeseries received by the receiver", "1")
+	mReceiverDroppedTimeSeries  = stats.Int64("otelsvc/receiver/dropped_timeseries", "Counts the number of timeseries dropped by the receiver", "1")
 
-	mExporterReceivedSpans = stats.Int64("otelsvc/exporter/received_spans", "Counts the number of spans received by the exporter", "1")
-	mExporterDroppedSpans  = stats.Int64("otelsvc/exporter/dropped_spans", "Counts the number of spans received by the exporter", "1")
+	mExporterReceivedSpans      = stats.Int64("otelsvc/exporter/received_spans", "Counts the number of spans received by the exporter", "1")
+	mExporterDroppedSpans       = stats.Int64("otelsvc/exporter/dropped_spans", "Counts the number of spans received by the exporter", "1")
+	mExporterReceivedTimeSeries = stats.Int64("otelsvc/exporter/received_timeseries", "Counts the number of timeseries received by the exporter", "1")
+	mExporterDroppedTimeSeries  = stats.Int64("otelsvc/exporter/dropped_timeseries", "Counts the number of timeseries received by the exporter", "1")
 )
 
 // TagKeyReceiver defines tag key for Receiver.
@@ -62,6 +66,24 @@ var ViewReceiverDroppedSpans = &view.View{
 	TagKeys:     []tag.Key{TagKeyReceiver},
 }
 
+// ViewReceiverReceivedTimeSeries defines the view for the receiver received timeseries metric.
+var ViewReceiverReceivedTimeSeries = &view.View{
+	Name:        mReceiverReceivedTimeSeries.Name(),
+	Description: mReceiverReceivedTimeSeries.Description(),
+	Measure:     mReceiverReceivedTimeSeries,
+	Aggregation: view.Sum(),
+	TagKeys:     []tag.Key{TagKeyReceiver},
+}
+
+// ViewReceiverDroppedTimeSeries defines the view for the receiver dropped timeseries metric.
+var ViewReceiverDroppedTimeSeries = &view.View{
+	Name:        mReceiverDroppedTimeSeries.Name(),
+	Description: mReceiverDroppedTimeSeries.Description(),
+	Measure:     mReceiverDroppedTimeSeries,
+	Aggregation: view.Sum(),
+	TagKeys:     []tag.Key{TagKeyReceiver},
+}
+
 // ViewExporterReceivedSpans defines the view for the exporter received spans metric.
 var ViewExporterReceivedSpans = &view.View{
 	Name:        mExporterReceivedSpans.Name(),
@@ -80,12 +102,34 @@ var ViewExporterDroppedSpans = &view.View{
 	TagKeys:     []tag.Key{TagKeyReceiver, TagKeyExporter},
 }
 
+// ViewExporterReceivedTimeSeries defines the view for the exporter received timeseries metric.
+var ViewExporterReceivedTimeSeries = &view.View{
+	Name:        mExporterReceivedTimeSeries.Name(),
+	Description: mExporterReceivedTimeSeries.Description(),
+	Measure:     mExporterReceivedTimeSeries,
+	Aggregation: view.Sum(),
+	TagKeys:     []tag.Key{TagKeyReceiver, TagKeyExporter},
+}
+
+// ViewExporterDroppedTimeSeries defines the view for the exporter dropped timeseries metric.
+var ViewExporterDroppedTimeSeries = &view.View{
+	Name:        mExporterDroppedTimeSeries.Name(),
+	Description: mExporterDroppedTimeSeries.Description(),
+	Measure:     mExporterDroppedTimeSeries,
+	Aggregation: view.Sum(),
+	TagKeys:     []tag.Key{TagKeyReceiver, TagKeyExporter},
+}
+
 // AllViews has the views for the metrics provided by the agent.
 var AllViews = []*view.View{
 	ViewReceiverReceivedSpans,
 	ViewReceiverDroppedSpans,
+	ViewReceiverReceivedTimeSeries,
+	ViewReceiverDroppedTimeSeries,
 	ViewExporterReceivedSpans,
 	ViewExporterDroppedSpans,
+	ViewExporterReceivedTimeSeries,
+	ViewExporterDroppedTimeSeries,
 }
 
 // ContextWithReceiverName adds the tag "otelsvc_receiver" and the name of the receiver as the value,
@@ -96,10 +140,16 @@ func ContextWithReceiverName(ctx context.Context, receiverName string) context.C
 	return ctx
 }
 
-// RecordMetricsForTraceReceiver records the number of the spans received and dropped by the receiver.
+// RecordMetricsForTraceReceiver records the number of spans received and dropped by the receiver.
 // Use it with a context.Context generated using ContextWithReceiverName().
 func RecordMetricsForTraceReceiver(ctxWithTraceReceiverName context.Context, receivedSpans int, droppedSpans int) {
 	stats.Record(ctxWithTraceReceiverName, mReceiverReceivedSpans.M(int64(receivedSpans)), mReceiverDroppedSpans.M(int64(droppedSpans)))
+}
+
+// RecordMetricsForMetricsReceiver records the number of timeseries received and dropped by the receiver.
+// Use it with a context.Context generated using ContextWithReceiverName().
+func RecordMetricsForMetricsReceiver(ctxWithTraceReceiverName context.Context, receivedTimeSeries int, droppedTimeSeries int) {
+	stats.Record(ctxWithTraceReceiverName, mReceiverReceivedTimeSeries.M(int64(receivedTimeSeries)), mReceiverDroppedTimeSeries.M(int64(droppedTimeSeries)))
 }
 
 // ContextWithExporterName adds the tag "otelsvc_exporter" and the name of the exporter as the value,
@@ -110,10 +160,16 @@ func ContextWithExporterName(ctx context.Context, exporterName string) context.C
 	return ctx
 }
 
-// RecordMetricsForTraceExporter records the number of the spans received and dropped by the exporter.
+// RecordMetricsForTraceExporter records the number of spans received and dropped by the exporter.
 // Use it with a context.Context generated using ContextWithExporterName().
 func RecordMetricsForTraceExporter(ctx context.Context, receivedSpans int, droppedSpans int) {
 	stats.Record(ctx, mExporterReceivedSpans.M(int64(receivedSpans)), mExporterDroppedSpans.M(int64(droppedSpans)))
+}
+
+// RecordMetricsForMetricsExporter records the number of timeseries received and dropped by the exporter.
+// Use it with a context.Context generated using ContextWithExporterName().
+func RecordMetricsForMetricsExporter(ctx context.Context, receivedTimeSeries int, droppedTimeSeries int) {
+	stats.Record(ctx, mExporterReceivedTimeSeries.M(int64(receivedTimeSeries)), mExporterDroppedTimeSeries.M(int64(droppedTimeSeries)))
 }
 
 // GRPCServerWithObservabilityEnabled creates a gRPC server that at a bare minimum has

--- a/observability/observability_test.go
+++ b/observability/observability_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-service/observability"
 	"github.com/open-telemetry/opentelemetry-service/observability/observabilitytest"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -37,16 +38,38 @@ func TestTracePieplineRecordedMetrics(t *testing.T) {
 	observability.RecordMetricsForTraceReceiver(receiverCtx, 17, 13)
 	exporterCtx := observability.ContextWithExporterName(receiverCtx, exporterName)
 	observability.RecordMetricsForTraceExporter(exporterCtx, 27, 23)
-	if err := observabilitytest.CheckValueViewReceiverReceivedSpans(receiverName, 17); err != nil {
-		t.Fatalf("When check recorded values: want nil got %v", err)
-	}
-	if err := observabilitytest.CheckValueViewReceiverDroppedSpans(receiverName, 13); err != nil {
-		t.Fatalf("When check recorded values: want nil got %v", err)
-	}
-	if err := observabilitytest.CheckValueViewExporterReceivedSpans(receiverName, exporterName, 27); err != nil {
-		t.Fatalf("When check recorded values: want nil got %v", err)
-	}
-	if err := observabilitytest.CheckValueViewExporterDroppedSpans(receiverName, exporterName, 23); err != nil {
-		t.Fatalf("When check recorded values: want nil got %v", err)
-	}
+
+	err := observabilitytest.CheckValueViewReceiverReceivedSpans(receiverName, 17)
+	require.Nil(t, err, "When check receiver received spans")
+
+	err = observabilitytest.CheckValueViewReceiverDroppedSpans(receiverName, 13)
+	require.Nil(t, err, "When check receiver dropped spans")
+
+	err = observabilitytest.CheckValueViewExporterReceivedSpans(receiverName, exporterName, 27)
+	require.Nil(t, err, "When check exporter received spans")
+
+	err = observabilitytest.CheckValueViewExporterDroppedSpans(receiverName, exporterName, 23)
+	require.Nil(t, err, "When check exporter dropped spans")
+}
+
+func TestMEtricsPieplineRecordedMetrics(t *testing.T) {
+	doneFn := observabilitytest.SetupRecordedMetricsTest()
+	defer doneFn()
+
+	receiverCtx := observability.ContextWithReceiverName(context.Background(), receiverName)
+	observability.RecordMetricsForMetricsReceiver(receiverCtx, 17, 13)
+	exporterCtx := observability.ContextWithExporterName(receiverCtx, exporterName)
+	observability.RecordMetricsForMetricsExporter(exporterCtx, 27, 23)
+
+	err := observabilitytest.CheckValueViewReceiverReceivedTimeSeries(receiverName, 17)
+	require.Nil(t, err, "When check receiver received timeseries")
+
+	err = observabilitytest.CheckValueViewReceiverDroppedTimeSeries(receiverName, 13)
+	require.Nil(t, err, "When check receiver dropped timeseries")
+
+	err = observabilitytest.CheckValueViewExporterReceivedTimeSeries(receiverName, exporterName, 27)
+	require.Nil(t, err, "When check exporter received timeseries")
+
+	err = observabilitytest.CheckValueViewExporterDroppedTimeSeries(receiverName, exporterName, 23)
+	require.Nil(t, err, "When check exporter dropped timeseries")
 }

--- a/observability/observabilitytest/observabilitytest.go
+++ b/observability/observabilitytest/observabilitytest.go
@@ -52,6 +52,22 @@ func CheckValueViewExporterDroppedSpans(receiverName string, exporterTagName str
 		wantsTagsForExporterView(receiverName, exporterTagName), int64(value))
 }
 
+// CheckValueViewExporterReceivedTimeSeries checks that for the current exported value in the ViewExporterReceivedTimeSeries
+// for {TagKeyReceiver: receiverName, TagKeyExporter: exporterTagName} is equal to "value".
+// When this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+func CheckValueViewExporterReceivedTimeSeries(receiverName string, exporterTagName string, value int) error {
+	return checkValueForView(observability.ViewExporterReceivedTimeSeries.Name,
+		wantsTagsForExporterView(receiverName, exporterTagName), int64(value))
+}
+
+// CheckValueViewExporterDroppedTimeSeries checks that for the current exported value in the ViewExporterDroppedTimeSeries
+// for {TagKeyReceiver: receiverName} is equal to "value".
+// In tests that this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+func CheckValueViewExporterDroppedTimeSeries(receiverName string, exporterTagName string, value int) error {
+	return checkValueForView(observability.ViewExporterDroppedTimeSeries.Name,
+		wantsTagsForExporterView(receiverName, exporterTagName), int64(value))
+}
+
 // CheckValueViewReceiverReceivedSpans checks that for the current exported value in the ViewReceiverReceivedSpans
 // for {TagKeyReceiver: receiverName, TagKeyExporter: exporterTagName} is equal to "value".
 // In tests that this function is called it is required to also call SetupRecordedMetricsTest as first thing.
@@ -65,6 +81,22 @@ func CheckValueViewReceiverReceivedSpans(receiverName string, value int) error {
 // In tests that this function is called it is required to also call SetupRecordedMetricsTest as first thing.
 func CheckValueViewReceiverDroppedSpans(receiverName string, value int) error {
 	return checkValueForView(observability.ViewReceiverDroppedSpans.Name,
+		wantsTagsForReceiverView(receiverName), int64(value))
+}
+
+// CheckValueViewReceiverReceivedTimeSeries checks that for the current exported value in the ViewReceiverReceivedTimeSeries
+// for {TagKeyReceiver: receiverName, TagKeyExporter: exporterTagName} is equal to "value".
+// In tests that this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+func CheckValueViewReceiverReceivedTimeSeries(receiverName string, value int) error {
+	return checkValueForView(observability.ViewReceiverReceivedTimeSeries.Name,
+		wantsTagsForReceiverView(receiverName), int64(value))
+}
+
+// CheckValueViewReceiverDroppedTimeSeries checks that for the current exported value in the ViewReceiverDroppedTimeSeries
+// for {TagKeyReceiver: receiverName} is equal to "value".
+// In tests that this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+func CheckValueViewReceiverDroppedTimeSeries(receiverName string, value int) error {
+	return checkValueForView(observability.ViewReceiverDroppedTimeSeries.Name,
 		wantsTagsForReceiverView(receiverName), int64(value))
 }
 

--- a/observability/observabilitytest/observabilitytest_test.go
+++ b/observability/observabilitytest/observabilitytest_test.go
@@ -29,7 +29,7 @@ const (
 	exporterName = "fake_exporter"
 )
 
-func TestCheckValueViewReceiverViews(t *testing.T) {
+func TestCheckValueViewTraceReceiverViews(t *testing.T) {
 	doneFn := observabilitytest.SetupRecordedMetricsTest()
 	defer doneFn()
 
@@ -58,7 +58,36 @@ func TestCheckValueViewReceiverViews(t *testing.T) {
 	}
 }
 
-func TestCheckValueViewExporterViews(t *testing.T) {
+func TestCheckValueViewMetricsReceiverViews(t *testing.T) {
+	doneFn := observabilitytest.SetupRecordedMetricsTest()
+	defer doneFn()
+
+	receiverCtx := observability.ContextWithReceiverName(context.Background(), receiverName)
+	observability.RecordMetricsForMetricsReceiver(receiverCtx, 17, 13)
+	// Test expected values.
+	if err := observabilitytest.CheckValueViewReceiverReceivedTimeSeries(receiverName, 17); err != nil {
+		t.Fatalf("When check recorded values: want nil got %v", err)
+	}
+	if err := observabilitytest.CheckValueViewReceiverDroppedTimeSeries(receiverName, 13); err != nil {
+		t.Fatalf("When check recorded values: want nil got %v", err)
+	}
+	// Test unexpected tag values
+	if err := observabilitytest.CheckValueViewReceiverReceivedTimeSeries(exporterName, 17); err == nil {
+		t.Fatalf("When check recorded values: want not-nil got nil")
+	}
+	if err := observabilitytest.CheckValueViewReceiverDroppedTimeSeries(exporterName, 13); err == nil {
+		t.Fatalf("When check recorded values: want not-nil got nil")
+	}
+	// Test unexpected recorded values
+	if err := observabilitytest.CheckValueViewReceiverReceivedTimeSeries(receiverName, 13); err == nil {
+		t.Fatalf("When check recorded values: want not-nil got nil")
+	}
+	if err := observabilitytest.CheckValueViewReceiverDroppedTimeSeries(receiverName, 17); err == nil {
+		t.Fatalf("When check recorded values: want not-nil got nil")
+	}
+}
+
+func TestCheckValueViewTraceExporterViews(t *testing.T) {
 	doneFn := observabilitytest.SetupRecordedMetricsTest()
 	defer doneFn()
 
@@ -84,6 +113,36 @@ func TestCheckValueViewExporterViews(t *testing.T) {
 		t.Fatalf("When check recorded values: want not-nil got nil")
 	}
 	if err := observabilitytest.CheckValueViewExporterDroppedSpans(receiverName, exporterName, 17); err == nil {
+		t.Fatalf("When check recorded values: want not-nil got nil")
+	}
+}
+
+func TestCheckValueViewMetricsExporterViews(t *testing.T) {
+	doneFn := observabilitytest.SetupRecordedMetricsTest()
+	defer doneFn()
+
+	receiverCtx := observability.ContextWithReceiverName(context.Background(), receiverName)
+	exporterCtx := observability.ContextWithExporterName(receiverCtx, exporterName)
+	observability.RecordMetricsForMetricsExporter(exporterCtx, 17, 13)
+	// Test expected values.
+	if err := observabilitytest.CheckValueViewExporterReceivedTimeSeries(receiverName, exporterName, 17); err != nil {
+		t.Fatalf("When check recorded values: want nil got %v", err)
+	}
+	if err := observabilitytest.CheckValueViewExporterDroppedTimeSeries(receiverName, exporterName, 13); err != nil {
+		t.Fatalf("When check recorded values: want nil got %v", err)
+	}
+	// Test unexpected tag values
+	if err := observabilitytest.CheckValueViewExporterReceivedTimeSeries(receiverName, receiverName, 17); err == nil {
+		t.Fatalf("When check recorded values: want not-nil got nil")
+	}
+	if err := observabilitytest.CheckValueViewExporterDroppedTimeSeries(receiverName, receiverName, 13); err == nil {
+		t.Fatalf("When check recorded values: want not-nil got nil")
+	}
+	// Test unexpected recorded values
+	if err := observabilitytest.CheckValueViewExporterReceivedTimeSeries(receiverName, exporterName, 13); err == nil {
+		t.Fatalf("When check recorded values: want not-nil got nil")
+	}
+	if err := observabilitytest.CheckValueViewExporterDroppedTimeSeries(receiverName, exporterName, 17); err == nil {
 		t.Fatalf("When check recorded values: want not-nil got nil")
 	}
 }

--- a/observability/observabilitytest/observabilitytest_test.go
+++ b/observability/observabilitytest/observabilitytest_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-service/observability"
 	"github.com/open-telemetry/opentelemetry-service/observability/observabilitytest"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -36,26 +37,22 @@ func TestCheckValueViewTraceReceiverViews(t *testing.T) {
 	receiverCtx := observability.ContextWithReceiverName(context.Background(), receiverName)
 	observability.RecordMetricsForTraceReceiver(receiverCtx, 17, 13)
 	// Test expected values.
-	if err := observabilitytest.CheckValueViewReceiverReceivedSpans(receiverName, 17); err != nil {
-		t.Fatalf("When check recorded values: want nil got %v", err)
-	}
-	if err := observabilitytest.CheckValueViewReceiverDroppedSpans(receiverName, 13); err != nil {
-		t.Fatalf("When check recorded values: want nil got %v", err)
-	}
+	err := observabilitytest.CheckValueViewReceiverReceivedSpans(receiverName, 17)
+	require.Nil(t, err, "When check receiver received spans")
+	err = observabilitytest.CheckValueViewReceiverDroppedSpans(receiverName, 13)
+	require.Nil(t, err, "When check receiver dropped spans")
+
 	// Test unexpected tag values
-	if err := observabilitytest.CheckValueViewReceiverReceivedSpans(exporterName, 17); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
-	if err := observabilitytest.CheckValueViewReceiverDroppedSpans(exporterName, 13); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
+	err = observabilitytest.CheckValueViewReceiverReceivedSpans(exporterName, 17)
+	require.NotNil(t, err, "When check for unexpected tag value")
+	err = observabilitytest.CheckValueViewReceiverDroppedSpans(exporterName, 13)
+	require.NotNil(t, err, "When check for unexpected tag value")
+
 	// Test unexpected recorded values
-	if err := observabilitytest.CheckValueViewReceiverReceivedSpans(receiverName, 13); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
-	if err := observabilitytest.CheckValueViewReceiverDroppedSpans(receiverName, 17); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
+	err = observabilitytest.CheckValueViewReceiverReceivedSpans(receiverName, 13)
+	require.NotNil(t, err, "When check for unexpected value")
+	err = observabilitytest.CheckValueViewReceiverDroppedSpans(receiverName, 17)
+	require.NotNil(t, err, "When check for unexpected value")
 }
 
 func TestCheckValueViewMetricsReceiverViews(t *testing.T) {
@@ -65,26 +62,22 @@ func TestCheckValueViewMetricsReceiverViews(t *testing.T) {
 	receiverCtx := observability.ContextWithReceiverName(context.Background(), receiverName)
 	observability.RecordMetricsForMetricsReceiver(receiverCtx, 17, 13)
 	// Test expected values.
-	if err := observabilitytest.CheckValueViewReceiverReceivedTimeSeries(receiverName, 17); err != nil {
-		t.Fatalf("When check recorded values: want nil got %v", err)
-	}
-	if err := observabilitytest.CheckValueViewReceiverDroppedTimeSeries(receiverName, 13); err != nil {
-		t.Fatalf("When check recorded values: want nil got %v", err)
-	}
+	err := observabilitytest.CheckValueViewReceiverReceivedTimeSeries(receiverName, 17)
+	require.Nil(t, err, "When check receiver received timeseries")
+	err = observabilitytest.CheckValueViewReceiverDroppedTimeSeries(receiverName, 13)
+	require.Nil(t, err, "When check receiver dropped timeseries")
+
 	// Test unexpected tag values
-	if err := observabilitytest.CheckValueViewReceiverReceivedTimeSeries(exporterName, 17); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
-	if err := observabilitytest.CheckValueViewReceiverDroppedTimeSeries(exporterName, 13); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
+	err = observabilitytest.CheckValueViewReceiverReceivedTimeSeries(exporterName, 17)
+	require.NotNil(t, err, "When check for unexpected tag value")
+	err = observabilitytest.CheckValueViewReceiverDroppedTimeSeries(exporterName, 13)
+	require.NotNil(t, err, "When check for unexpected tag value")
+
 	// Test unexpected recorded values
-	if err := observabilitytest.CheckValueViewReceiverReceivedTimeSeries(receiverName, 13); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
-	if err := observabilitytest.CheckValueViewReceiverDroppedTimeSeries(receiverName, 17); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
+	err = observabilitytest.CheckValueViewReceiverReceivedTimeSeries(receiverName, 13)
+	require.NotNil(t, err, "When check for unexpected value")
+	err = observabilitytest.CheckValueViewReceiverDroppedTimeSeries(receiverName, 17)
+	require.NotNil(t, err, "When check for unexpected value")
 }
 
 func TestCheckValueViewTraceExporterViews(t *testing.T) {
@@ -95,26 +88,22 @@ func TestCheckValueViewTraceExporterViews(t *testing.T) {
 	exporterCtx := observability.ContextWithExporterName(receiverCtx, exporterName)
 	observability.RecordMetricsForTraceExporter(exporterCtx, 17, 13)
 	// Test expected values.
-	if err := observabilitytest.CheckValueViewExporterReceivedSpans(receiverName, exporterName, 17); err != nil {
-		t.Fatalf("When check recorded values: want nil got %v", err)
-	}
-	if err := observabilitytest.CheckValueViewExporterDroppedSpans(receiverName, exporterName, 13); err != nil {
-		t.Fatalf("When check recorded values: want nil got %v", err)
-	}
+	err := observabilitytest.CheckValueViewExporterReceivedSpans(receiverName, exporterName, 17)
+	require.Nil(t, err, "When check exporter received spans")
+	err = observabilitytest.CheckValueViewExporterDroppedSpans(receiverName, exporterName, 13)
+	require.Nil(t, err, "When check exporter dropped spans")
+
 	// Test unexpected tag values
-	if err := observabilitytest.CheckValueViewExporterReceivedSpans(receiverName, receiverName, 17); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
-	if err := observabilitytest.CheckValueViewExporterDroppedSpans(receiverName, receiverName, 13); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
+	err = observabilitytest.CheckValueViewExporterReceivedSpans(receiverName, receiverName, 17)
+	require.NotNil(t, err, "When check for unexpected tag value")
+	err = observabilitytest.CheckValueViewExporterDroppedSpans(receiverName, receiverName, 13)
+	require.NotNil(t, err, "When check for unexpected tag value")
+
 	// Test unexpected recorded values
-	if err := observabilitytest.CheckValueViewExporterReceivedSpans(receiverName, exporterName, 13); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
-	if err := observabilitytest.CheckValueViewExporterDroppedSpans(receiverName, exporterName, 17); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
+	err = observabilitytest.CheckValueViewExporterReceivedSpans(receiverName, exporterName, 13)
+	require.NotNil(t, err, "When check for unexpected value")
+	err = observabilitytest.CheckValueViewExporterDroppedSpans(receiverName, exporterName, 17)
+	require.NotNil(t, err, "When check for unexpected value")
 }
 
 func TestCheckValueViewMetricsExporterViews(t *testing.T) {
@@ -125,33 +114,28 @@ func TestCheckValueViewMetricsExporterViews(t *testing.T) {
 	exporterCtx := observability.ContextWithExporterName(receiverCtx, exporterName)
 	observability.RecordMetricsForMetricsExporter(exporterCtx, 17, 13)
 	// Test expected values.
-	if err := observabilitytest.CheckValueViewExporterReceivedTimeSeries(receiverName, exporterName, 17); err != nil {
-		t.Fatalf("When check recorded values: want nil got %v", err)
-	}
-	if err := observabilitytest.CheckValueViewExporterDroppedTimeSeries(receiverName, exporterName, 13); err != nil {
-		t.Fatalf("When check recorded values: want nil got %v", err)
-	}
+	err := observabilitytest.CheckValueViewExporterReceivedTimeSeries(receiverName, exporterName, 17)
+	require.Nil(t, err, "When check exporter received timeseries")
+	err = observabilitytest.CheckValueViewExporterDroppedTimeSeries(receiverName, exporterName, 13)
+	require.Nil(t, err, "When check exporter dropped timeseries")
+
 	// Test unexpected tag values
-	if err := observabilitytest.CheckValueViewExporterReceivedTimeSeries(receiverName, receiverName, 17); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
-	if err := observabilitytest.CheckValueViewExporterDroppedTimeSeries(receiverName, receiverName, 13); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
+	err = observabilitytest.CheckValueViewExporterReceivedTimeSeries(receiverName, receiverName, 17)
+	require.NotNil(t, err, "When check for unexpected tag value")
+	err = observabilitytest.CheckValueViewExporterDroppedTimeSeries(receiverName, receiverName, 13)
+	require.NotNil(t, err, "When check for unexpected tag value")
+
 	// Test unexpected recorded values
-	if err := observabilitytest.CheckValueViewExporterReceivedTimeSeries(receiverName, exporterName, 13); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
-	if err := observabilitytest.CheckValueViewExporterDroppedTimeSeries(receiverName, exporterName, 17); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
+	err = observabilitytest.CheckValueViewExporterReceivedTimeSeries(receiverName, exporterName, 13)
+	require.NotNil(t, err, "When check for unexpected value")
+	err = observabilitytest.CheckValueViewExporterDroppedTimeSeries(receiverName, exporterName, 17)
+	require.NotNil(t, err, "When check for unexpected value")
 }
 
 func TestNoSetupCalled(t *testing.T) {
 	receiverCtx := observability.ContextWithReceiverName(context.Background(), receiverName)
 	observability.RecordMetricsForTraceReceiver(receiverCtx, 17, 13)
 	// Failed to check because views are not registered.
-	if err := observabilitytest.CheckValueViewReceiverReceivedSpans(receiverName, 17); err == nil {
-		t.Fatalf("When check recorded values: want not-nil got nil")
-	}
+	err := observabilitytest.CheckValueViewReceiverReceivedSpans(receiverName, 17)
+	require.NotNil(t, err, "When check with no views registered")
 }


### PR DESCRIPTION
By mistake I created this on top of https://github.com/open-telemetry/opentelemetry-service/pull/314. Will wait for that to merge first.