### PR TITLE
Expose public method to create OC Exporter

### DIFF
--- a/exporter/opencensusexporter/factory.go
+++ b/exporter/opencensusexporter/factory.go
@@ -63,7 +63,7 @@ func (f *Factory) CreateTraceExporter(logger *zap.Logger, config configmodels.Ex
 	if err != nil {
 		return nil, err
 	}
-	return f.CreateOCAgentTraceExporter(logger, ocac, opts)
+	return f.CreateTraceExporterExtendOptions(logger, ocac, opts)
 }
 
 // createOCAgentExporter takes ocagent exporter options and create an OC exporter
@@ -85,11 +85,10 @@ func (f *Factory) createOCAgentExporter(logger *zap.Logger, ocac *Config, opts [
 	return oce, nil
 }
 
-// CreateOCAgentTraceExporter is a wrapper around creating the OC agent exporter and
-// returning it as the TraceExporter interface.
-// This method is exposed to allow for extending the options OC Agent supports
-// in forks.
-func (f *Factory) CreateOCAgentTraceExporter(logger *zap.Logger, ocac *Config, opts []ocagent.ExporterOption) (exporter.TraceExporter, error) {
+// CreateTraceExporterExtendOptions exposes the options as a parameter to the
+// construction of the underlying OC Exporter.
+// This is useful for forks that extend OC Exporter functionalities.
+func (f *Factory) CreateTraceExporterExtendOptions(logger *zap.Logger, ocac *Config, opts []ocagent.ExporterOption) (exporter.TraceExporter, error) {
 	oce, err := f.createOCAgentExporter(logger, ocac, opts)
 	if err != nil {
 		return nil, err

--- a/exporter/opencensusexporter/factory.go
+++ b/exporter/opencensusexporter/factory.go
@@ -28,7 +28,6 @@ import (
 	compressiongrpc "github.com/open-telemetry/opentelemetry-service/compression/grpc"
 	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-service/exporter"
-	"github.com/open-telemetry/opentelemetry-service/exporter/exporterhelper"
 )
 
 const (
@@ -63,47 +62,7 @@ func (f *Factory) CreateTraceExporter(logger *zap.Logger, config configmodels.Ex
 	if err != nil {
 		return nil, err
 	}
-	return f.CreateTraceExporterExtendOptions(logger, ocac, opts)
-}
-
-// createOCAgentExporter takes ocagent exporter options and create an OC exporter
-func (f *Factory) createOCAgentExporter(logger *zap.Logger, ocac *Config, opts []ocagent.ExporterOption) (*ocagentExporter, error) {
-	numWorkers := defaultNumWorkers
-	if ocac.NumWorkers > 0 {
-		numWorkers = ocac.NumWorkers
-	}
-
-	exportersChan := make(chan *ocagent.Exporter, numWorkers)
-	for exporterIndex := 0; exporterIndex < numWorkers; exporterIndex++ {
-		exporter, serr := ocagent.NewExporter(opts...)
-		if serr != nil {
-			return nil, fmt.Errorf("cannot configure OpenCensus exporter: %v", serr)
-		}
-		exportersChan <- exporter
-	}
-	oce := &ocagentExporter{exporters: exportersChan}
-	return oce, nil
-}
-
-// CreateTraceExporterExtendOptions exposes the options as a parameter to the
-// construction of the underlying OC Exporter.
-// This is useful for forks that extend OC Exporter functionalities.
-func (f *Factory) CreateTraceExporterExtendOptions(logger *zap.Logger, ocac *Config, opts []ocagent.ExporterOption) (exporter.TraceExporter, error) {
-	oce, err := f.createOCAgentExporter(logger, ocac, opts)
-	if err != nil {
-		return nil, err
-	}
-	oexp, err := exporterhelper.NewTraceExporter(
-		"oc_trace",
-		oce.PushTraceData,
-		exporterhelper.WithSpanName("otelservice.exporter.OpenCensus.ConsumeTraceData"),
-		exporterhelper.WithRecordMetrics(true),
-		exporterhelper.WithShutdown(oce.Shutdown))
-	if err != nil {
-		return nil, err
-	}
-
-	return oexp, nil
+	return NewTraceExporter(logger, config, opts...)
 }
 
 // OCAgentOptions takes the oc exporter Config and generates ocagent Options
@@ -166,27 +125,10 @@ func (f *Factory) OCAgentOptions(logger *zap.Logger, ocac *Config) ([]ocagent.Ex
 
 // CreateMetricsExporter creates a metrics exporter based on this config.
 func (f *Factory) CreateMetricsExporter(logger *zap.Logger, config configmodels.Exporter) (exporter.MetricsExporter, error) {
-	ocac := config.(*Config)
-	opts, err := f.OCAgentOptions(logger, ocac)
+	oCfg := config.(*Config)
+	opts, err := f.OCAgentOptions(logger, oCfg)
 	if err != nil {
 		return nil, err
 	}
-	oce, err := f.createOCAgentExporter(logger, ocac, opts)
-	if err != nil {
-		return nil, err
-	}
-	// TODO https://github.com/open-telemetry/opentelemetry-service/issues/265
-	//	What is the exporterName used for? Should this be the full name of the exporter or just the type?
-	oexp, err := exporterhelper.NewMetricsExporter(
-		"oc_metrics",
-		oce.PushMetricsData,
-		exporterhelper.WithSpanName("otelservice.exporter.OpenCensus.ConsumeMetricsData"),
-		exporterhelper.WithRecordMetrics(true),
-		exporterhelper.WithShutdown(oce.Shutdown))
-
-	if err != nil {
-		return nil, err
-	}
-
-	return oexp, nil
+	return NewMetricsExporter(logger, config, opts...)
 }

--- a/exporter/opencensusexporter/factory.go
+++ b/exporter/opencensusexporter/factory.go
@@ -64,6 +64,7 @@ func (f *Factory) CreateTraceExporter(logger *zap.Logger, config configmodels.Ex
 	}
 	return NewTraceExporter(logger, config, opts...)
 }
+
 // OCAgentOptions takes the oc exporter Config and generates ocagent Options
 func (f *Factory) OCAgentOptions(logger *zap.Logger, ocac *Config) ([]ocagent.ExporterOption, error) {
 	if ocac.Endpoint == "" {

--- a/exporter/opencensusexporter/opencensus.go
+++ b/exporter/opencensusexporter/opencensus.go
@@ -23,8 +23,11 @@ import (
 	"contrib.go.opencensus.io/exporter/ocagent"
 	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
+	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-service/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-service/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-service/exporter"
 	"github.com/open-telemetry/opentelemetry-service/exporter/exporterhelper"
 	"github.com/open-telemetry/opentelemetry-service/oterr"
 )
@@ -37,7 +40,7 @@ type KeepaliveConfig struct {
 	PermitWithoutStream bool          `mapstructure:"permit-without-stream,omitempty"`
 }
 
-type ocagentExporter struct {
+type ocAgentExporter struct {
 	exporters chan *ocagent.Exporter
 }
 
@@ -67,7 +70,65 @@ const (
 	errAlreadyStopped
 )
 
-func (oce *ocagentExporter) Shutdown() error {
+// NewTraceExporter creates an Open Census trace exporter.
+func NewTraceExporter(logger *zap.Logger, config configmodels.Exporter, opts ...ocagent.ExporterOption) (exporter.TraceExporter, error) {
+	oce, err := createOCAgentExporter(logger, config, opts...)
+	if err != nil {
+		return nil, err
+	}
+	oexp, err := exporterhelper.NewTraceExporter(
+		"oc_trace",
+		oce.PushTraceData,
+		exporterhelper.WithSpanName("otelservice.exporter.OpenCensus.ConsumeTraceData"),
+		exporterhelper.WithRecordMetrics(true),
+		exporterhelper.WithShutdown(oce.Shutdown))
+	if err != nil {
+		return nil, err
+	}
+
+	return oexp, nil
+}
+
+// createOCAgentExporter takes ocagent exporter options and create an OC exporter
+func createOCAgentExporter(logger *zap.Logger, config configmodels.Exporter, opts ...ocagent.ExporterOption) (*ocAgentExporter, error) {
+	oCfg := config.(*Config)
+	numWorkers := defaultNumWorkers
+	if oCfg.NumWorkers > 0 {
+		numWorkers = oCfg.NumWorkers
+	}
+
+	exportersChan := make(chan *ocagent.Exporter, numWorkers)
+	for exporterIndex := 0; exporterIndex < numWorkers; exporterIndex++ {
+		exporter, serr := ocagent.NewExporter(opts...)
+		if serr != nil {
+			return nil, fmt.Errorf("cannot configure OpenCensus exporter: %v", serr)
+		}
+		exportersChan <- exporter
+	}
+	oce := &ocAgentExporter{exporters: exportersChan}
+	return oce, nil
+}
+
+// NewMetricsExporter creates an Open Census metrics exporter.
+func NewMetricsExporter(logger *zap.Logger, config configmodels.Exporter, opts ...ocagent.ExporterOption) (exporter.MetricsExporter, error) {
+	oce, err := createOCAgentExporter(logger, config, opts...)
+	if err != nil {
+		return nil, err
+	}
+	oexp, err := exporterhelper.NewMetricsExporter(
+		"oc_metrics",
+		oce.PushMetricsData,
+		exporterhelper.WithSpanName("otelservice.exporter.OpenCensus.ConsumeMetricsData"),
+		exporterhelper.WithRecordMetrics(true),
+		exporterhelper.WithShutdown(oce.Shutdown))
+	if err != nil {
+		return nil, err
+	}
+
+	return oexp, nil
+}
+
+func (oce *ocAgentExporter) Shutdown() error {
 	wg := &sync.WaitGroup{}
 	var errors []error
 	var errorsMu sync.Mutex
@@ -96,7 +157,7 @@ func (oce *ocagentExporter) Shutdown() error {
 	return oterr.CombineErrors(errors)
 }
 
-func (oce *ocagentExporter) PushTraceData(ctx context.Context, td consumerdata.TraceData) (int, error) {
+func (oce *ocAgentExporter) PushTraceData(ctx context.Context, td consumerdata.TraceData) (int, error) {
 	// Get first available exporter.
 	exporter, ok := <-oce.exporters
 	if !ok {
@@ -121,7 +182,7 @@ func (oce *ocagentExporter) PushTraceData(ctx context.Context, td consumerdata.T
 	return 0, nil
 }
 
-func (oce *ocagentExporter) PushMetricsData(ctx context.Context, md consumerdata.MetricsData) (int, error) {
+func (oce *ocAgentExporter) PushMetricsData(ctx context.Context, md consumerdata.MetricsData) (int, error) {
 	// Get first available exporter.
 	exporter, ok := <-oce.exporters
 	if !ok {


### PR DESCRIPTION
Refactor OC Exporter creation to expose New(Trace/Metrics)Exporter to be use by forks that extend OC Exporter. 

There is no observable functional changes in this service. 
cc @owais @tigrannajaryan 
