### PR TITLE
Add observability instrumentation for Prometheus receiver

### DIFF
--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -45,6 +45,8 @@ type metricBuilder struct {
 	hasInternalMetric bool
 	mc                MetadataCache
 	metrics           []*metricspb.Metric
+	numTimeseries     int
+	droppedTimeseries int
 	logger            *zap.SugaredLogger
 	currentMf         MetricFamily
 }
@@ -55,9 +57,11 @@ type metricBuilder struct {
 func newMetricBuilder(mc MetadataCache, logger *zap.SugaredLogger) *metricBuilder {
 
 	return &metricBuilder{
-		mc:      mc,
-		metrics: make([]*metricspb.Metric, 0),
-		logger:  logger,
+		mc:                mc,
+		metrics:           make([]*metricspb.Metric, 0),
+		logger:            logger,
+		numTimeseries:     0,
+		droppedTimeseries: 0,
 	}
 }
 
@@ -65,19 +69,23 @@ func newMetricBuilder(mc MetadataCache, logger *zap.SugaredLogger) *metricBuilde
 func (b *metricBuilder) AddDataPoint(ls labels.Labels, t int64, v float64) error {
 	metricName := ls.Get(model.MetricNameLabel)
 	if metricName == "" {
+		b.numTimeseries++
+		b.droppedTimeseries++
 		return errMetricNameNotFound
 	} else if shouldSkip(metricName) {
 		b.hasInternalMetric = true
 		lm := ls.Map()
 		delete(lm, model.MetricNameLabel)
-		b.logger.Infow("skip internal metric", "name", metricName, "ts", t, "value", v, "labels", lm)
+		//b.logger.Infow("skip internal metric", "name", metricName, "ts", t, "value", v, "labels", lm)
 		return nil
 	}
 
 	b.hasData = true
 
 	if b.currentMf != nil && !b.currentMf.IsSameFamily(metricName) {
-		m := b.currentMf.ToMetric()
+		m, ts, dts := b.currentMf.ToMetric()
+		b.numTimeseries += ts
+		b.droppedTimeseries += dts
 		if m != nil {
 			b.metrics = append(b.metrics, m)
 		}
@@ -90,22 +98,25 @@ func (b *metricBuilder) AddDataPoint(ls labels.Labels, t int64, v float64) error
 }
 
 // Build is to build an opencensus data.MetricsData based on all added data complexValue
-func (b *metricBuilder) Build() ([]*metricspb.Metric, error) {
+func (b *metricBuilder) Build() ([]*metricspb.Metric, int, int, error) {
 	if !b.hasData {
 		if b.hasInternalMetric {
-			return dummyMetrics, nil
+			return dummyMetrics, 0, 0, nil
 		}
-		return nil, errNoDataToBuild
+		return nil, 0, 0, errNoDataToBuild
 	}
 
 	if b.currentMf != nil {
-		if m := b.currentMf.ToMetric(); m != nil {
+		m, ts, dts := b.currentMf.ToMetric()
+		b.numTimeseries += ts
+		b.droppedTimeseries += dts
+		if m != nil {
 			b.metrics = append(b.metrics, m)
 		}
 		b.currentMf = nil
 	}
 
-	return b.metrics, nil
+	return b.metrics, b.numTimeseries, b.droppedTimeseries, nil
 }
 
 // TODO: move the following helper functions to a proper place, as they are not called directly in this go file

--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -76,7 +76,7 @@ func (b *metricBuilder) AddDataPoint(ls labels.Labels, t int64, v float64) error
 		b.hasInternalMetric = true
 		lm := ls.Map()
 		delete(lm, model.MetricNameLabel)
-		//b.logger.Infow("skip internal metric", "name", metricName, "ts", t, "value", v, "labels", lm)
+		b.logger.Infow("skip internal metric", "name", metricName, "ts", t, "value", v, "labels", lm)
 		return nil
 	}
 

--- a/receiver/prometheusreceiver/internal/metricsbuilder_test.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder_test.go
@@ -102,7 +102,7 @@ func runBuilderTests(t *testing.T, tests []buildTestData) {
 						t.Error("unexpected error adding data", err)
 					}
 				}
-				metrics, err := b.Build()
+				metrics, _, _, err := b.Build()
 				if err != nil {
 					t.Error("unexpected error on build", err)
 				}
@@ -1073,7 +1073,7 @@ func Test_metricBuilder_baddata(t *testing.T) {
 			return
 		}
 
-		if _, err := b.Build(); err != errNoDataToBuild {
+		if _, _, _, err := b.Build(); err != errNoDataToBuild {
 			t.Error("expecting errNoDataToBuild error, but get nil")
 		}
 	})

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-service/consumer"
+	"github.com/open-telemetry/opentelemetry-service/observability"
 	"github.com/open-telemetry/opentelemetry-service/receiver"
 	"github.com/open-telemetry/opentelemetry-service/receiver/prometheusreceiver/internal"
 
@@ -138,6 +139,7 @@ func (pr *Preceiver) StartMetricsReception(host receiver.Host) error {
 		ctx := host.Context()
 		c, cancel := context.WithCancel(ctx)
 		pr.cancel = cancel
+		c = observability.ContextWithReceiverName(c, pr.MetricsSource())
 		jobsMap := internal.NewJobsMap(time.Duration(2 * time.Minute))
 		app := internal.NewOcaStore(c, pr.consumer, pr.logger.Sugar(), jobsMap)
 		// need to use a logger with the gokitLog interface

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -139,7 +139,7 @@ func (pr *Preceiver) StartMetricsReception(host receiver.Host) error {
 		ctx := host.Context()
 		c, cancel := context.WithCancel(ctx)
 		pr.cancel = cancel
-		c = observability.ContextWithReceiverName(c, pr.MetricsSource())
+		c = observability.ContextWithReceiverName(c, observability.MakeComponentName(typeStr, pr.MetricsSource()))
 		jobsMap := internal.NewJobsMap(time.Duration(2 * time.Minute))
 		app := internal.NewOcaStore(c, pr.consumer, pr.logger.Sugar(), jobsMap)
 		// need to use a logger with the gokitLog interface

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -139,7 +139,8 @@ func (pr *Preceiver) StartMetricsReception(host receiver.Host) error {
 		ctx := host.Context()
 		c, cancel := context.WithCancel(ctx)
 		pr.cancel = cancel
-		c = observability.ContextWithReceiverName(c, observability.MakeComponentName(typeStr, pr.MetricsSource()))
+		// TODO: Use the name from the ReceiverSettings
+		c = observability.ContextWithReceiverName(c, observability.MakeComponentName(typeStr, ""))
 		jobsMap := internal.NewJobsMap(time.Duration(2 * time.Minute))
 		app := internal.NewOcaStore(c, pr.consumer, pr.logger.Sugar(), jobsMap)
 		// need to use a logger with the gokitLog interface


### PR DESCRIPTION
The pr instrument the Prometheus receiver using the observability metrics library. Adding this instrumentation will allow users to monitor service that rely on this receiver.