### PR TITLE
Allow metric processors to be specified in pipelines

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -739,6 +739,7 @@ func validatePipelineProcessors(
 			}
 		}
 	}
+	
 	// Validate pipeline processor name references
 	for _, ref := range pipeline.Processors {
 		// Check that the name referenced in the pipeline's processors exists in the top-level processors.

--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,6 @@ const (
 	errPipelineReceiverNotExists
 	errPipelineProcessorNotExists
 	errPipelineExporterNotExists
-	errMetricPipelineCannotHaveProcessors
 	errUnmarshalError
 	errMissingReceivers
 	errMissingExporters

--- a/config/config.go
+++ b/config/config.go
@@ -738,16 +738,7 @@ func validatePipelineProcessors(
 				msg:  fmt.Sprintf("pipeline %q must have at least one processor", pipeline.Name),
 			}
 		}
-	} else if pipeline.InputType == configmodels.MetricsDataType {
-		// Metrics pipeline cannot have processors.
-		if len(pipeline.Processors) > 0 {
-			return &configError{
-				code: errMetricPipelineCannotHaveProcessors,
-				msg:  fmt.Sprintf("metrics pipeline %q cannot have processors", pipeline.Name),
-			}
-		}
 	}
-
 	// Validate pipeline processor name references
 	for _, ref := range pipeline.Processors {
 		// Check that the name referenced in the pipeline's processors exists in the top-level processors.

--- a/config/config.go
+++ b/config/config.go
@@ -739,7 +739,7 @@ func validatePipelineProcessors(
 			}
 		}
 	}
-	
+
 	// Validate pipeline processor name references
 	for _, ref := range pipeline.Processors {
 		// Check that the name referenced in the pipeline's processors exists in the top-level processors.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -201,7 +201,6 @@ func TestDecodeConfig_Invalid(t *testing.T) {
 		{name: "pipeline-exporter-not-exists", expected: errPipelineExporterNotExists},
 		{name: "pipeline-processor-not-exists", expected: errPipelineProcessorNotExists},
 		{name: "pipeline-must-have-processors", expected: errPipelineMustHaveProcessors},
-		{name: "metric-pipeline-cannot-have-processors", expected: errMetricPipelineCannotHaveProcessors},
 		{name: "unknown-extension-type", expected: errUnknownExtensionType},
 		{name: "unknown-receiver-type", expected: errUnknownReceiverType},
 		{name: "unknown-exporter-type", expected: errUnknownExporterType},


### PR DESCRIPTION
The current pipeline configuration prevents metric processors from being registered. I need this feature for some work I'm doing so I'd like to enable it.