### PR TITLE
Add option to disable the Prometheus metrics adjuster

### DIFF
--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -28,5 +28,6 @@ type Config struct {
 	PrometheusConfig              *config.Config      `mapstructure:"-"`
 	BufferPeriod                  time.Duration       `mapstructure:"buffer_period"`
 	BufferCount                   int                 `mapstructure:"buffer_count"`
+	DisableMetricsAdjuster        bool                `mapstructure:"disabe_metrics_adjuster"`
 	IncludeFilter                 map[string][]string `mapstructure:"include_filter"`
 }

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -28,6 +28,6 @@ type Config struct {
 	PrometheusConfig              *config.Config      `mapstructure:"-"`
 	BufferPeriod                  time.Duration       `mapstructure:"buffer_period"`
 	BufferCount                   int                 `mapstructure:"buffer_count"`
-	DisableMetricsAdjuster        bool                `mapstructure:"disabe_metrics_adjuster"`
+	DisableMetricsAdjuster        bool                `mapstructure:"disable_metrics_adjuster"`
 	IncludeFilter                 map[string][]string `mapstructure:"include_filter"`
 }

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -51,6 +51,7 @@ func TestLoadConfig(t *testing.T) {
 		})
 	assert.Equal(t, r1.PrometheusConfig.ScrapeConfigs[0].JobName, "demo")
 	assert.Equal(t, time.Duration(r1.PrometheusConfig.ScrapeConfigs[0].ScrapeInterval), 5*time.Second)
+	assert.True(t, r1.DisableMetricsAdjuster)
 	wantFilter := map[string][]string{
 		"localhost:9777": {"http/server/server_latency", "custom_metric1"},
 		"localhost:9778": {"http/client/roundtrip_latency"},

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -118,10 +118,11 @@ func (f *Factory) CreateMetricsReceiver(
 
 	// Create receiver Configuration from our input cfg
 	config := Configuration{
-		BufferCount:   rCfg.BufferCount,
-		BufferPeriod:  rCfg.BufferPeriod,
-		ScrapeConfig:  rCfg.PrometheusConfig,
-		IncludeFilter: rCfg.IncludeFilter,
+		BufferCount:            rCfg.BufferCount,
+		BufferPeriod:           rCfg.BufferPeriod,
+		ScrapeConfig:           rCfg.PrometheusConfig,
+		DisableMetricsAdjuster: rCfg.DisableMetricsAdjuster,
+		IncludeFilter:          rCfg.IncludeFilter,
 	}
 
 	if config.ScrapeConfig == nil || len(config.ScrapeConfig.ScrapeConfigs) == 0 {

--- a/receiver/prometheusreceiver/testdata/config.yaml
+++ b/receiver/prometheusreceiver/testdata/config.yaml
@@ -4,6 +4,7 @@ receivers:
     endpoint: "1.2.3.4:456"
     buffer_period: 234
     buffer_count: 45
+    disable_metrics_adjuster: true
     include_filter: {
       "localhost:9777" : [http/server/server_latency, custom_metric1],
       "localhost:9778" : [http/client/roundtrip_latency],


### PR DESCRIPTION
The Prometheus metrics adjuster is used to deal issues related to unknown start times, which are not provided by Prometheus.

Some systems may want to provided this information and deal with the issue specifically so provide a flag to disable the metrics adjuster when it's not needed.