### PR TITLE
Change the observability component name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -93,8 +93,8 @@ const (
 	pipelinesKeyName = "pipelines"
 )
 
-// typeAndNameSeparator is the separator that is used between type and name in type/name composite keys.
-const typeAndNameSeparator = "/"
+// TypeAndNameSeparator is the separator that is used between type and name in type/name composite keys.
+const TypeAndNameSeparator = "/"
 
 // Factories struct holds in a single type all component factories that
 // can be handled by the Config.
@@ -176,7 +176,7 @@ func Load(
 // fullName is the key normalized such that type and name components have spaces trimmed.
 // The "type" part must be present, the forward slash and "name" are optional.
 func decodeTypeAndName(key string) (typeStr, fullName string, err error) {
-	items := strings.SplitN(key, typeAndNameSeparator, 2)
+	items := strings.SplitN(key, TypeAndNameSeparator, 2)
 
 	if len(items) >= 1 {
 		typeStr = strings.TrimSpace(items[0])
@@ -192,7 +192,7 @@ func decodeTypeAndName(key string) (typeStr, fullName string, err error) {
 		// "name" part is present.
 		nameSuffix = strings.TrimSpace(items[1])
 		if nameSuffix == "" {
-			err = errors.New("name part must be specified after " + typeAndNameSeparator + " in type/name key")
+			err = errors.New("name part must be specified after " + TypeAndNameSeparator + " in type/name key")
 			return
 		}
 	} else {
@@ -203,7 +203,7 @@ func decodeTypeAndName(key string) (typeStr, fullName string, err error) {
 	if nameSuffix == "" {
 		fullName = typeStr
 	} else {
-		fullName = typeStr + typeAndNameSeparator + nameSuffix
+		fullName = typeStr + TypeAndNameSeparator + nameSuffix
 	}
 
 	err = nil

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -33,7 +33,7 @@ import (
 const (
 	fakeMetricsReceiverName     = "fake_receiver"
 	fakeMetricsExporterType     = "fake_metrics_exporter"
-	fakeMetricsExporterName     = "with_name"
+	fakeMetricsExporterName     = "fake_metrics_exporter/with_name"
 	fakeMetricsExporterFullName = "fake_metrics_exporter_with_name"
 	fakeMetricsParentSpanName   = "fake_metrics_parent_span_name"
 )

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -34,7 +34,7 @@ import (
 const (
 	fakeTraceReceiverName     = "fake_receiver_trace"
 	fakeTraceExporterType     = "fake_trace_exporter"
-	fakeTraceExporterName     = "with_name"
+	fakeTraceExporterName     = "fake_trace_exporter/with_name"
 	fakeTraceExporterFullName = "fake_trace_exporter_with_name"
 	fakeTraceParentSpanName   = "fake_trace_parent_span_name"
 )

--- a/observability/observability_test.go
+++ b/observability/observability_test.go
@@ -76,8 +76,10 @@ func TestMetricsPieplineRecordedMetrics(t *testing.T) {
 
 func TestMakeComponentName(t *testing.T) {
 	const fakeType = "type"
-	const fakeName = "name"
+	const fakeName = "type/name"
 	const fakeComponentName = "type_name"
 	require.Equal(t, fakeType, observability.MakeComponentName(fakeType, ""))
+	require.Equal(t, fakeType, observability.MakeComponentName(fakeType, fakeType))
+	require.Equal(t, fakeType, observability.MakeComponentName(fakeType, "not_normalized_name"))
 	require.Equal(t, fakeComponentName, observability.MakeComponentName(fakeType, fakeName))
 }


### PR DESCRIPTION
I did not know that the Name in every component is the fully qualified name (not just the suffix). For observability we want to use `type_name` instead of `type/name`. `/` is an invalid character in a some metrics backends.