### PR TITLE
Remove observability special name construction and use the full name

### DIFF
--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -56,8 +56,6 @@ func NewMetricsExporter(config configmodels.Exporter, pushMetricsData PushMetric
 		return nil, errNilConfig
 	}
 
-	exporterFullName := observability.MakeComponentName(config.Type(), config.Name())
-
 	if pushMetricsData == nil {
 		return nil, errNilPushMetricsData
 	}
@@ -68,7 +66,7 @@ func NewMetricsExporter(config configmodels.Exporter, pushMetricsData PushMetric
 	}
 
 	if opts.recordTrace {
-		pushMetricsData = pushMetricsDataWithSpan(pushMetricsData, exporterFullName+".ExportMetricsData")
+		pushMetricsData = pushMetricsDataWithSpan(pushMetricsData, config.Name()+".ExportMetricsData")
 	}
 
 	// The default shutdown method always returns nil.
@@ -77,7 +75,7 @@ func NewMetricsExporter(config configmodels.Exporter, pushMetricsData PushMetric
 	}
 
 	return &metricsExporter{
-		exporterFullName: exporterFullName,
+		exporterFullName: config.Name(),
 		pushMetricsData:  pushMetricsData,
 		shutdown:         opts.shutdown,
 	}, nil

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -31,11 +31,10 @@ import (
 )
 
 const (
-	fakeMetricsReceiverName     = "fake_receiver"
-	fakeMetricsExporterType     = "fake_metrics_exporter"
-	fakeMetricsExporterName     = "with_name"
-	fakeMetricsExporterFullName = "fake_metrics_exporter_with_name"
-	fakeMetricsParentSpanName   = "fake_metrics_parent_span_name"
+	fakeMetricsReceiverName   = "fake_receiver"
+	fakeMetricsExporterType   = "fake_metrics_exporter"
+	fakeMetricsExporterName   = "fake_metrics_exporter/with_name"
+	fakeMetricsParentSpanName = "fake_metrics_parent_span_name"
 )
 
 var (
@@ -171,10 +170,10 @@ func checkRecordedMetricsForMetricsExporter(t *testing.T, me exporter.MetricsExp
 		require.Equal(t, wantError, me.ConsumeMetricsData(ctx, md))
 	}
 
-	err := observabilitytest.CheckValueViewExporterReceivedTimeSeries(fakeMetricsReceiverName, fakeMetricsExporterFullName, numBatches*NumTimeSeries(md))
+	err := observabilitytest.CheckValueViewExporterReceivedTimeSeries(fakeMetricsReceiverName, fakeMetricsExporterName, numBatches*NumTimeSeries(md))
 	require.Nilf(t, err, "CheckValueViewExporterTimeSeries: Want nil Got %v", err)
 
-	err = observabilitytest.CheckValueViewExporterDroppedTimeSeries(fakeMetricsReceiverName, fakeMetricsExporterFullName, numBatches*droppedTimeSeries)
+	err = observabilitytest.CheckValueViewExporterDroppedTimeSeries(fakeMetricsReceiverName, fakeMetricsExporterName, numBatches*droppedTimeSeries)
 	require.Nilf(t, err, "CheckValueViewExporterTimeSeries: Want nil Got %v", err)
 }
 

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -56,8 +56,6 @@ func NewTraceExporter(config configmodels.Exporter, pushTraceData PushTraceData,
 		return nil, errNilConfig
 	}
 
-	exporterFullName := observability.MakeComponentName(config.Type(), config.Name())
-
 	if pushTraceData == nil {
 		return nil, errNilPushTraceData
 	}
@@ -68,7 +66,7 @@ func NewTraceExporter(config configmodels.Exporter, pushTraceData PushTraceData,
 	}
 
 	if opts.recordTrace {
-		pushTraceData = pushTraceDataWithSpan(pushTraceData, exporterFullName+".ExportTraceData")
+		pushTraceData = pushTraceDataWithSpan(pushTraceData, config.Name()+".ExportTraceData")
 	}
 
 	// The default shutdown function returns nil.
@@ -79,7 +77,7 @@ func NewTraceExporter(config configmodels.Exporter, pushTraceData PushTraceData,
 	}
 
 	return &traceExporter{
-		exporterFullName: exporterFullName,
+		exporterFullName: config.Name(),
 		pushTraceData:    pushTraceData,
 		shutdown:         opts.shutdown,
 	}, nil

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -32,11 +32,10 @@ import (
 )
 
 const (
-	fakeTraceReceiverName     = "fake_receiver_trace"
-	fakeTraceExporterType     = "fake_trace_exporter"
-	fakeTraceExporterName     = "with_name"
-	fakeTraceExporterFullName = "fake_trace_exporter_with_name"
-	fakeTraceParentSpanName   = "fake_trace_parent_span_name"
+	fakeTraceReceiverName   = "fake_receiver_trace"
+	fakeTraceExporterType   = "fake_trace_exporter"
+	fakeTraceExporterName   = "fake_trace_exporter/with_name"
+	fakeTraceParentSpanName = "fake_trace_parent_span_name"
 )
 
 var (
@@ -173,10 +172,10 @@ func checkRecordedMetricsForTraceExporter(t *testing.T, te exporter.TraceExporte
 		require.Equal(t, wantError, te.ConsumeTraceData(ctx, td))
 	}
 
-	err := observabilitytest.CheckValueViewExporterReceivedSpans(fakeTraceReceiverName, fakeTraceExporterFullName, numBatches*len(spans))
+	err := observabilitytest.CheckValueViewExporterReceivedSpans(fakeTraceReceiverName, fakeTraceExporterName, numBatches*len(spans))
 	require.Nilf(t, err, "CheckValueViewExporterReceivedSpans: Want nil Got %v", err)
 
-	err = observabilitytest.CheckValueViewExporterDroppedSpans(fakeTraceReceiverName, fakeTraceExporterFullName, numBatches*droppedSpans)
+	err = observabilitytest.CheckValueViewExporterDroppedSpans(fakeTraceReceiverName, fakeTraceExporterName, numBatches*droppedSpans)
 	require.Nilf(t, err, "CheckValueViewExporterDroppedSpans: Want nil Got %v", err)
 }
 

--- a/observability/observability.go
+++ b/observability/observability.go
@@ -172,15 +172,6 @@ func RecordMetricsForMetricsExporter(ctx context.Context, receivedTimeSeries int
 	stats.Record(ctx, mExporterReceivedTimeSeries.M(int64(receivedTimeSeries)), mExporterDroppedTimeSeries.M(int64(droppedTimeSeries)))
 }
 
-// MakeComponentName constructs the name of the component (for the moment receiver and exporter) that should be used for observability.
-// E.g. as a tag/metrics label or span name.
-func MakeComponentName(typeStr, name string) string {
-	if len(name) == 0 {
-		return typeStr
-	}
-	return typeStr + "_" + name
-}
-
 // GRPCServerWithObservabilityEnabled creates a gRPC server that at a bare minimum has
 // the OpenCensus ocgrpc server stats handler enabled for tracing and stats.
 // Use it instead of invoking grpc.NewServer directly.

--- a/observability/observability_test.go
+++ b/observability/observability_test.go
@@ -73,11 +73,3 @@ func TestMetricsPieplineRecordedMetrics(t *testing.T) {
 	err = observabilitytest.CheckValueViewExporterDroppedTimeSeries(receiverName, exporterName, 23)
 	require.Nil(t, err, "When check exporter dropped timeseries")
 }
-
-func TestMakeComponentName(t *testing.T) {
-	const fakeType = "type"
-	const fakeName = "name"
-	const fakeComponentName = "type_name"
-	require.Equal(t, fakeType, observability.MakeComponentName(fakeType, ""))
-	require.Equal(t, fakeComponentName, observability.MakeComponentName(fakeType, fakeName))
-}

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -41,6 +41,7 @@ type Preceiver struct {
 	consumer         consumer.MetricsConsumer
 	cancel           context.CancelFunc
 	logger           *zap.Logger
+	receiverFullName string
 	includeFilterMap map[string]metricsMap
 }
 
@@ -64,6 +65,7 @@ func newPrometheusReceiver(logger *zap.Logger, cfg *Config, next consumer.Metric
 		cfg:              cfg,
 		consumer:         next,
 		logger:           logger,
+		receiverFullName: cfg.Name(),
 		includeFilterMap: parseIncludeFilter(cfg.IncludeFilter),
 	}
 	return pr
@@ -84,7 +86,7 @@ func (pr *Preceiver) StartMetricsReception(host receiver.Host) error {
 		c, cancel := context.WithCancel(ctx)
 		pr.cancel = cancel
 		// TODO: Use the name from the ReceiverSettings
-		c = observability.ContextWithReceiverName(c, observability.MakeComponentName(typeStr, ""))
+		c = observability.ContextWithReceiverName(c, pr.receiverFullName)
 		jobsMap := internal.NewJobsMap(time.Duration(2 * time.Minute))
 		app := internal.NewOcaStore(c, pr.consumer, pr.logger.Sugar(), jobsMap)
 		// need to use a logger with the gokitLog interface


### PR DESCRIPTION
The "Name" property of the config confused me and believed that it is not the full name `type/name` because in documentation we refer to `type` and `name`. Maybe we should have a `Name` and `FullName` (NormalizedName).