### PR TITLE
Fixed loop variable pointer bug in jaeger translator

### DIFF
--- a/translator/trace/jaeger/protospan_to_jaegerproto.go
+++ b/translator/trace/jaeger/protospan_to_jaegerproto.go
@@ -138,18 +138,21 @@ func ocNodeAndResourceToJaegerProcessProto(node *commonpb.Node, resource *resour
 	if resource != nil {
 		resourceType := resource.GetType()
 		if resourceType != "" {
-			jTags = append(jTags, jaeger.KeyValue{
+			resourceTypeTag := jaeger.KeyValue{
 				Key:   opencensusResourceType,
 				VType: jaeger.ValueType_STRING,
 				VStr:  resourceType,
-			})
+			}
+			jTags = append(jTags, resourceTypeTag)
 		}
 		for k, v := range resource.GetLabels() {
-			jTags = append(jTags, jaeger.KeyValue{
+			str := v
+			resourceTag := jaeger.KeyValue{
 				Key:   k,
 				VType: jaeger.ValueType_STRING,
-				VStr:  v,
-			})
+				VStr:  str,
+			}
+			jTags = append(jTags, resourceTag)
 		}
 	}
 

--- a/translator/trace/jaeger/protospan_to_jaegerthrift.go
+++ b/translator/trace/jaeger/protospan_to_jaegerthrift.go
@@ -136,18 +136,21 @@ func ocNodeAndResourceToJaegerProcess(node *commonpb.Node, resource *resourcepb.
 	if resource != nil {
 		resourceType := resource.GetType()
 		if resourceType != "" {
-			jTags = append(jTags, &jaeger.Tag{
+			resourceTypeTag := &jaeger.Tag{
 				Key:   opencensusResourceType,
 				VType: jaeger.TagType_STRING,
 				VStr:  &resourceType,
-			})
+			}
+			jTags = append(jTags, resourceTypeTag)
 		}
 		for k, v := range resource.GetLabels() {
-			jTags = append(jTags, &jaeger.Tag{
+			str := v
+			resourceTag := &jaeger.Tag{
 				Key:   k,
 				VType: jaeger.TagType_STRING,
-				VStr:  &v,
-			})
+				VStr:  &str,
+			}
+			jTags = append(jTags, resourceTag)
 		}
 	}
 


### PR DESCRIPTION
Jaeger translator was taking address of the loop variable when copying
span tags. This resulted in all destination tags having same values.
This PR fixes the bug and also uses one common code pattern for all
copying code so that copy pasting in future does not introduce similar
bugs.