### PR TITLE
Change log statement in Prometheus receiver from info to debug.

### DIFF
--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -76,7 +76,7 @@ func (b *metricBuilder) AddDataPoint(ls labels.Labels, t int64, v float64) error
 		b.hasInternalMetric = true
 		lm := ls.Map()
 		delete(lm, model.MetricNameLabel)
-		b.logger.Infow("skip internal metric", "name", metricName, "ts", t, "value", v, "labels", lm)
+		b.logger.Debugw("skip internal metric", "name", metricName, "ts", t, "value", v, "labels", lm)
 		return nil
 	}
 

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -134,16 +134,16 @@ func (tr *transaction) Commit() error {
 		// never added any data points, that the transaction has not been initialized.
 		return nil
 	}
+
 	metrics, numTimeseries, droppedTimeseries, err := tr.metricBuilder.Build()
 	observability.RecordMetricsForMetricsReceiver(tr.ctx, numTimeseries, droppedTimeseries)
 	if err != nil {
 		return err
 	}
-	if tr.jobsMap != nil {
-		// Note: metrics could be empty after adjustment, which needs to be checked before passing it on to ConsumeMetricsData()
-		metrics = NewMetricsAdjuster(tr.jobsMap.get(tr.job, tr.instance), tr.logger).AdjustMetrics(metrics)
-	}
 	if len(metrics) > 0 {
+		if tr.jobsMap != nil {
+			metrics = NewMetricsAdjuster(tr.jobsMap.get(tr.job, tr.instance), tr.logger).AdjustMetrics(metrics)
+		}
 		md := consumerdata.MetricsData{
 			Node:    tr.node,
 			Metrics: metrics,

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -134,16 +134,15 @@ func (tr *transaction) Commit() error {
 		// never added any data points, that the transaction has not been initialized.
 		return nil
 	}
-
 	metrics, numTimeseries, droppedTimeseries, err := tr.metricBuilder.Build()
 	observability.RecordMetricsForMetricsReceiver(tr.ctx, numTimeseries, droppedTimeseries)
 	if err != nil {
 		return err
 	}
+	if tr.jobsMap != nil {
+		metrics = NewMetricsAdjuster(tr.jobsMap.get(tr.job, tr.instance), tr.logger).AdjustMetrics(metrics)
+	}
 	if len(metrics) > 0 {
-		if tr.jobsMap != nil {
-			metrics = NewMetricsAdjuster(tr.jobsMap.get(tr.job, tr.instance), tr.logger).AdjustMetrics(metrics)
-		}
 		md := consumerdata.MetricsData{
 			Node:    tr.node,
 			Metrics: metrics,

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -140,6 +140,7 @@ func (tr *transaction) Commit() error {
 		return err
 	}
 	if tr.jobsMap != nil {
+		// Note: metrics could be empty after adjustment, which needs to be checked before passing it on to ConsumeMetricsData()
 		metrics = NewMetricsAdjuster(tr.jobsMap.get(tr.job, tr.instance), tr.logger).AdjustMetrics(metrics)
 	}
 	if len(metrics) > 0 {


### PR DESCRIPTION
This change to the Prometheus receiver will prevent unnecessary log messages under normal usage.