### PR TITLE
Prometheus Receiver: Ensure that ConsumeMetricsData() is not passed empty metrics

### DIFF
--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -140,10 +140,11 @@ func (tr *transaction) Commit() error {
 	if err != nil {
 		return err
 	}
+	// Note: metrics could be empty after adjustment, which needs to be checked before passing it on to ConsumeMetricsData()
+	if tr.jobsMap != nil {
+		metrics = NewMetricsAdjuster(tr.jobsMap.get(tr.job, tr.instance), tr.logger).AdjustMetrics(metrics)
+	}
 	if len(metrics) > 0 {
-		if tr.jobsMap != nil {
-			metrics = NewMetricsAdjuster(tr.jobsMap.get(tr.job, tr.instance), tr.logger).AdjustMetrics(metrics)
-		}
 		md := consumerdata.MetricsData{
 			Node:    tr.node,
 			Metrics: metrics,


### PR DESCRIPTION
This change fixes an issue where the call to the metrics adjuster could result in an empty slice of metrics being passed to ConsumeMetricsData().