### PR TITLE
Remove network access popups on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Build the Agent and start it with the example configuration:
 
 ```shell
 $ ./bin/$(go env GOOS)/otelsvc  --config ./examples/demo/otel-agent-config.yaml
-$ 2018/10/08 21:38:00 Running OpenTelemetry receiver as a gRPC service at "127.0.0.1:55678"
+$ 2018/10/08 21:38:00 Running OpenTelemetry receiver as a gRPC service at "localhost:55678"
 ```
 
 Create an Collector [configuration](#config) file based on the options
@@ -155,10 +155,10 @@ README.md](receiver/README.md).
 ```yaml
 receivers:
   opencensus:
-    address: "127.0.0.1:55678"
+    address: "localhost:55678"
 
   zipkin:
-    address: "127.0.0.1:9411"
+    address: "localhost:9411"
 
   jaeger:
     jaeger-thrift-tchannel-port: 14267
@@ -189,14 +189,14 @@ exporters:
     headers: {"X-test-header": "test-header"}
     compression: "gzip"
     cert-pem-file: "server_ca_public.pem" # optional to enable TLS
-    endpoint: "127.0.0.1:55678"
+    endpoint: "localhost:55678"
     reconnection-delay: 2s
 
   jaeger:
-    collector_endpoint: "http://127.0.0.1:14268/api/traces"
+    collector_endpoint: "http://localhost:14268/api/traces"
 
   zipkin:
-    endpoint: "http://127.0.0.1:9411/api/v2/spans"
+    endpoint: "http://localhost:9411/api/v2/spans"
 ```
 
 ### <a name="config-pipelines"></a>Pipelines

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -64,7 +64,7 @@ func TestDecodeConfig(t *testing.T) {
 			ReceiverSettings: configmodels.ReceiverSettings{
 				TypeVal:  "examplereceiver",
 				NameVal:  "examplereceiver/myreceiver",
-				Endpoint: "127.0.0.1:12345",
+				Endpoint: "localhost:12345",
 			},
 			ExtraSetting: "some string",
 		},
@@ -230,7 +230,7 @@ func TestSimpleConfig(t *testing.T) {
 				ReceiverSettings: configmodels.ReceiverSettings{
 					TypeVal:  "examplereceiver",
 					NameVal:  "examplereceiver",
-					Endpoint: "127.0.0.1:1234",
+					Endpoint: "localhost:1234",
 				},
 				ExtraSetting:     receiverExtra,
 				ExtraMapSetting:  map[string]string{"recv.1": receiverExtraMapValue + "_1", "recv.2": receiverExtraMapValue + "_2"},
@@ -327,7 +327,7 @@ func TestDecodeConfig_MultiProto(t *testing.T) {
 			NameVal: "multireceiver/myreceiver",
 			Protocols: map[string]MultiProtoReceiverOneCfg{
 				"http": {
-					Endpoint:     "127.0.0.1:12345",
+					Endpoint:     "localhost:12345",
 					ExtraSetting: "some string 1",
 				},
 				"tcp": {

--- a/config/testdata/multiproto-config.yaml
+++ b/config/testdata/multiproto-config.yaml
@@ -3,7 +3,7 @@ receivers:
   multireceiver/myreceiver:
     protocols:
       http:
-        endpoint: "127.0.0.1:12345"
+        endpoint: "localhost:12345"
         extra: "some string 1"
       tcp:
         endpoint: "0.0.0.0:4567"

--- a/config/testdata/simple-config-with-all-env.yaml
+++ b/config/testdata/simple-config-with-all-env.yaml
@@ -1,6 +1,6 @@
 receivers:
   examplereceiver:
-    endpoint: "127.0.0.1:1234"
+    endpoint: "localhost:1234"
     extra: "$RECEIVERS_EXAMPLERECEIVER_EXTRA"
     extra_map:
       recv.1: "$RECEIVERS_EXAMPLERECEIVER_EXTRA_MAP_RECV_VALUE_1"

--- a/config/testdata/simple-config-with-no-env.yaml
+++ b/config/testdata/simple-config-with-no-env.yaml
@@ -1,6 +1,6 @@
 receivers:
   examplereceiver:
-    endpoint: "127.0.0.1:1234"
+    endpoint: "localhost:1234"
     extra: "some receiver string"
     extra_map:
       recv.1: "some receiver map value_1"

--- a/config/testdata/simple-config-with-partial-env.yaml
+++ b/config/testdata/simple-config-with-partial-env.yaml
@@ -1,6 +1,6 @@
 receivers:
   examplereceiver:
-    endpoint: "127.0.0.1:1234"
+    endpoint: "localhost:1234"
     extra: "some receiver string"
     extra_map:
       recv.1: "some receiver map value_1"

--- a/config/testdata/valid-config.yaml
+++ b/config/testdata/valid-config.yaml
@@ -1,7 +1,7 @@
 receivers:
   examplereceiver:
   examplereceiver/myreceiver:
-    endpoint: "127.0.0.1:12345"
+    endpoint: "localhost:12345"
     extra: "some string"
   examplereceiver/disabled:
     disabled: true

--- a/docs/design.md
+++ b/docs/design.md
@@ -44,7 +44,7 @@ Receivers typically listen on a network port and receive telemetry data. Usually
 ```yaml
 receivers:
   opencensus:
-    endpoint: "127.0.0.1:55678”
+    endpoint: "localhost:55678”
 
 pipelines:
   traces:  # a pipeline of “traces” type
@@ -76,7 +76,7 @@ exporters:
   opencensus/1:
     endpoint: "example.com:14250”
   opencensus/2:
-    endpoint: "127.0.0.1:14250”
+    endpoint: "localhost:14250”
 ```
 
 Usually an exporter gets the data from one pipeline, however it is possible to configure multiple pipelines to send data to the same exporter, e.g.:
@@ -86,7 +86,7 @@ exporters:
   jaeger:
     protocols:
       grpc:
-        endpoint: "127.0.0.1:14250”
+        endpoint: "localhost:14250”
 
 pipelines:
   traces:  # a pipeline of “traces” type

--- a/docs/service-extensions.md
+++ b/docs/service-extensions.md
@@ -52,11 +52,11 @@ extensions:
   health-check:
     port: 13133
   pprof:
-    endpoint: "127.0.0.1:1777"
+    endpoint: "localhost:1777"
     block-profile-fraction: 0
     mutex-profile-fraction: 0
   zpages:
-   endpoint: "127.0.0.1:55679"
+   endpoint: "localhost:55679"
 
 # The service lists extensions not directly related to data pipelines, but used
 # by the service.

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -78,7 +78,7 @@ Example:
 ```yaml
 exporters:
   opencensus:
-    endpoint: 127.0.0.1:14250
+    endpoint: localhost:14250
     reconnection-delay: 60s
     secure: false
 ```

--- a/exporter/jaeger/jaegergrpcexporter/exporter_test.go
+++ b/exporter/jaeger/jaegergrpcexporter/exporter_test.go
@@ -38,7 +38,7 @@ func TestNew(t *testing.T) {
 			name: "empty_exporterName",
 			args: args{
 				config:            nil,
-				collectorEndpoint: "127.0.0.1:55678",
+				collectorEndpoint: "localhost:55678",
 			},
 			wantErr: true,
 		},

--- a/exporter/jaeger/jaegerthrifthttpexporter/factory_test.go
+++ b/exporter/jaeger/jaegerthrifthttpexporter/factory_test.go
@@ -87,7 +87,7 @@ func TestFactory_CreateTraceExporter(t *testing.T) {
 					TypeVal: typeStr,
 					NameVal: typeStr,
 				},
-				URL: "127.0.0.1:123",
+				URL: "localhost:123",
 			},
 			wantErr: true,
 		},

--- a/extension/README.md
+++ b/extension/README.md
@@ -53,10 +53,10 @@ extensions:
   # endpoint that can be used by the golang tool pprof to collect profiles.
   # The default values are listed below.
   pprof:
-    # The endpoint in which the pprof will be listening to. Use 127.0.0.1:<port>
+    # The endpoint in which the pprof will be listening to. Use localhost:<port>
     # to make it available only locally, or ":<port>" to make it available on
     # all network interfaces.
-    endpoint: 127.0.0.1:1777
+    endpoint: localhost:1777
     # Fraction of blocking events that are profiled. A value <= 0 disables
     # profiling. See https://golang.org/pkg/runtime/#SetBlockProfileRate for details.
     block-profile-fraction: 0
@@ -78,8 +78,8 @@ extensions:
   # to debug components of the service.
   zpages:
     # Specifies the HTTP endpoint is going to be opened to serve zPages.
-    # Use 127.0.0.1:<port> to make it available only locally, or ":<port>" to
+    # Use localhost:<port> to make it available only locally, or ":<port>" to
     # make it available on all network interfaces.
     # The default value is listed below.
-    endpoint: 127.0.0.1:55679
+    endpoint: localhost:55679
 ```

--- a/extension/healthcheckextension/healthcheckextension_test.go
+++ b/extension/healthcheckextension/healthcheckextension_test.go
@@ -68,12 +68,16 @@ func TestHealthCheckExtensionUsage(t *testing.T) {
 
 func TestHealthCheckExtensionPortAlreadyInUse(t *testing.T) {
 	endpoint := testutils.GetAvailableLocalAddress(t)
-	ln, err := net.Listen("tcp", endpoint)
+	_, portStr, err := net.SplitHostPort(endpoint)
+	require.NoError(t, err)
+
+	// This needs to be ":port" because health checks also tries to connect to ":port".
+	// To avoid the pop-up "accept incoming network connections" health check should be changed
+	// to accept an address.
+	ln, err := net.Listen("tcp", ":"+portStr)
 	require.NoError(t, err)
 	defer ln.Close()
 
-	_, portStr, err := net.SplitHostPort(endpoint)
-	require.NoError(t, err)
 	port, err := strconv.Atoi(portStr)
 	require.NoError(t, err)
 

--- a/extension/pprofextension/config.go
+++ b/extension/pprofextension/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	configmodels.ExtensionSettings `mapstructure:",squash"`
 
 	// Endpoint is the address and port in which the pprof will be listening to.
-	// Use 127.0.0.1:<port> to make it available only locally, or ":<port>" to
+	// Use localhost:<port> to make it available only locally, or ":<port>" to
 	// make it available on all network interfaces.
 	Endpoint string `mapstructure:"endpoint"`
 

--- a/extension/pprofextension/factory.go
+++ b/extension/pprofextension/factory.go
@@ -47,7 +47,7 @@ func (f *Factory) CreateDefaultConfig() configmodels.Extension {
 			TypeVal: typeStr,
 			NameVal: typeStr,
 		},
-		Endpoint: "127.0.0.1:1777",
+		Endpoint: "localhost:1777",
 	}
 }
 

--- a/extension/pprofextension/factory_test.go
+++ b/extension/pprofextension/factory_test.go
@@ -39,7 +39,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 			NameVal: typeStr,
 			TypeVal: typeStr,
 		},
-		Endpoint: "127.0.0.1:1777",
+		Endpoint: "localhost:1777",
 	},
 		cfg)
 

--- a/extension/zpagesextension/config.go
+++ b/extension/zpagesextension/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	configmodels.ExtensionSettings `mapstructure:",squash"`
 
 	// Endpoint is the address and port in which the zPages will be listening to.
-	// Use 127.0.0.1:<port> to make it available only locally, or ":<port>" to
+	// Use localhost:<port> to make it available only locally, or ":<port>" to
 	// make it available on all network interfaces.
 	Endpoint string `mapstructure:"endpoint"`
 }

--- a/extension/zpagesextension/config_test.go
+++ b/extension/zpagesextension/config_test.go
@@ -46,7 +46,7 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: "zpages",
 				NameVal: "zpages/1",
 			},
-			Endpoint: "127.0.0.1:56888",
+			Endpoint: "localhost:56888",
 		},
 		ext1)
 

--- a/extension/zpagesextension/factory.go
+++ b/extension/zpagesextension/factory.go
@@ -47,7 +47,7 @@ func (f *Factory) CreateDefaultConfig() configmodels.Extension {
 			TypeVal: typeStr,
 			NameVal: typeStr,
 		},
-		Endpoint: "127.0.0.1:55679",
+		Endpoint: "localhost:55679",
 	}
 }
 

--- a/extension/zpagesextension/factory_test.go
+++ b/extension/zpagesextension/factory_test.go
@@ -39,7 +39,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 			NameVal: typeStr,
 			TypeVal: typeStr,
 		},
-		Endpoint: "127.0.0.1:55679",
+		Endpoint: "localhost:55679",
 	},
 		cfg)
 

--- a/extension/zpagesextension/testdata/config.yaml
+++ b/extension/zpagesextension/testdata/config.yaml
@@ -1,7 +1,7 @@
 extensions:
   zpages:
   zpages/1:
-    endpoint: "127.0.0.1:56888"
+    endpoint: "localhost:56888"
 
 service:
   extensions: [zpages/1]

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -39,7 +39,7 @@ func GenerateNormalizedJSON(j string) string {
 // provided that there is no race by some other code to grab the same port
 // immediately.
 func GetAvailableLocalAddress(t *testing.T) string {
-	ln, err := net.Listen("tcp", ":0")
+	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("failed to get a free local port: %v", err)
 	}

--- a/internal/testutils/testutils_test.go
+++ b/internal/testutils/testutils_test.go
@@ -30,7 +30,7 @@ func TestGetAvailablePort(t *testing.T) {
 	portStr := strconv.Itoa(int(GetAvailablePort(t)))
 	require.NotEqual(t, "", portStr)
 
-	testEndpointAvailable(t, "127.0.0.1:"+portStr)
+	testEndpointAvailable(t, "localhost:"+portStr)
 }
 
 func testEndpointAvailable(t *testing.T, endpoint string) {

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -34,7 +34,7 @@ receivers:
     # <setting one>: <value one>
     disabled: false
     # <setting two>: <value two>
-    endpoint: 127.0.0.1:9211
+    endpoint: localhost:9211
 ```
 
 A receiver instance is referenced by its full name in other parts of the config,
@@ -137,7 +137,7 @@ receivers:
         tls-credentials:
           key-file: /key.pem # path to private key
           cert-file: /cert.pem # path to certificate
-        endpoint: "127.0.0.1:9876"
+        endpoint: "localhost:9876"
 ``` 
 ## <a name="prometheus"></a>Prometheus Receiver
 **Only metrics are supported.**
@@ -211,7 +211,7 @@ For example:
 ```yaml
 receivers:
   zipkin:
-    address: "127.0.0.1:9411"
+    address: "localhost:9411"
 ```
 
 ## Common Configuration Errors

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -52,7 +52,7 @@ func TestLoadConfig(t *testing.T) {
 			Protocols: map[string]*receiver.SecureReceiverSettings{
 				"grpc": {
 					ReceiverSettings: configmodels.ReceiverSettings{
-						Endpoint: "127.0.0.1:9876",
+						Endpoint: "localhost:9876",
 					},
 				},
 				"thrift-http": {
@@ -77,7 +77,7 @@ func TestLoadConfig(t *testing.T) {
 			Protocols: map[string]*receiver.SecureReceiverSettings{
 				"grpc": {
 					ReceiverSettings: configmodels.ReceiverSettings{
-						Endpoint: "127.0.0.1:9876",
+						Endpoint: "localhost:9876",
 					},
 					TLSCredentials: &receiver.TLSCredentials{
 						CertFile: "/test.crt",

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -43,9 +43,9 @@ const (
 	protoThriftTChannel = "thrift-tchannel"
 
 	// Default endpoints to bind to.
-	defaultGRPCBindEndpoint     = "127.0.0.1:14250"
-	defaultHTTPBindEndpoint     = "127.0.0.1:14268"
-	defaultTChannelBindEndpoint = "127.0.0.1:14267"
+	defaultGRPCBindEndpoint     = "localhost:14250"
+	defaultHTTPBindEndpoint     = "localhost:14268"
+	defaultTChannelBindEndpoint = "localhost:14267"
 )
 
 // Factory is the factory for Jaeger receiver.

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -78,7 +78,7 @@ func TestCreateNoPort(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*Config)
 
-	rCfg.Protocols[protoThriftHTTP].Endpoint = "127.0.0.1:"
+	rCfg.Protocols[protoThriftHTTP].Endpoint = "localhost:"
 	_, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
 	assert.Error(t, err, "receiver creation with no port number must fail")
 }
@@ -88,7 +88,7 @@ func TestCreateLargePort(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*Config)
 
-	rCfg.Protocols[protoThriftHTTP].Endpoint = "127.0.0.1:65536"
+	rCfg.Protocols[protoThriftHTTP].Endpoint = "localhost:65536"
 	_, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
 	assert.Error(t, err, "receiver creation with too large port number must fail")
 }

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -10,7 +10,7 @@ receivers:
   jaeger/customname:
     protocols:
       grpc:
-        endpoint: "127.0.0.1:9876"
+        endpoint: "localhost:9876"
       thrift-http:
         endpoint: ":3456"
       thrift-tchannel:
@@ -41,7 +41,7 @@ receivers:
         tls-credentials:
           cert-file: /test.crt
           key-file: /test.key
-        endpoint: "127.0.0.1:9876"
+        endpoint: "localhost:9876"
       thrift-http:
         endpoint: ":3456"
       thrift-tchannel:

--- a/receiver/opencensusreceiver/config_test.go
+++ b/receiver/opencensusreceiver/config_test.go
@@ -60,7 +60,7 @@ func TestLoadConfig(t *testing.T) {
 				ReceiverSettings: configmodels.ReceiverSettings{
 					TypeVal:  typeStr,
 					NameVal:  "opencensus/keepalive",
-					Endpoint: "127.0.0.1:55678",
+					Endpoint: "localhost:55678",
 				},
 				TLSCredentials: nil,
 			},
@@ -86,7 +86,7 @@ func TestLoadConfig(t *testing.T) {
 				ReceiverSettings: configmodels.ReceiverSettings{
 					TypeVal:  typeStr,
 					NameVal:  "opencensus/msg-size-conc-connect-max-idle",
-					Endpoint: "127.0.0.1:55678",
+					Endpoint: "localhost:55678",
 				},
 			},
 			MaxRecvMsgSizeMiB:    32,
@@ -107,7 +107,7 @@ func TestLoadConfig(t *testing.T) {
 				ReceiverSettings: configmodels.ReceiverSettings{
 					TypeVal:  typeStr,
 					NameVal:  "opencensus/tlscredentials",
-					Endpoint: "127.0.0.1:55678",
+					Endpoint: "localhost:55678",
 				},
 				TLSCredentials: &receiver.TLSCredentials{
 					CertFile: "test.crt",
@@ -123,7 +123,7 @@ func TestLoadConfig(t *testing.T) {
 				ReceiverSettings: configmodels.ReceiverSettings{
 					TypeVal:  typeStr,
 					NameVal:  "opencensus/cors",
-					Endpoint: "127.0.0.1:55678",
+					Endpoint: "localhost:55678",
 				},
 			},
 			CorsOrigins: []string{"https://*.test.com", "https://test.com"},

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -51,7 +51,7 @@ func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 			ReceiverSettings: configmodels.ReceiverSettings{
 				TypeVal:  typeStr,
 				NameVal:  typeStr,
-				Endpoint: "127.0.0.1:55678",
+				Endpoint: "localhost:55678",
 				// Disable: false - This receiver is enabled by default.
 			},
 		},

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -80,7 +80,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 					ReceiverSettings: configmodels.ReceiverSettings{
 						TypeVal:  typeStr,
 						NameVal:  typeStr,
-						Endpoint: "127.0.0.1:112233",
+						Endpoint: "localhost:112233",
 					},
 				},
 			},

--- a/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
@@ -342,7 +342,7 @@ func (sa *metricAppender) ConsumeMetricsData(ctx context.Context, md consumerdat
 }
 
 func ocReceiverOnGRPCServer(t *testing.T, sr consumer.MetricsConsumer, opts ...Option) (oci *Receiver, port int, done func()) {
-	ln, err := net.Listen("tcp", ":0")
+	ln, err := net.Listen("tcp", "127.0.0.1:")
 	if err != nil {
 		t.Fatalf("Failed to find an available address to run the gRPC server: %v", err)
 	}

--- a/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
@@ -342,7 +342,7 @@ func (sa *metricAppender) ConsumeMetricsData(ctx context.Context, md consumerdat
 }
 
 func ocReceiverOnGRPCServer(t *testing.T, sr consumer.MetricsConsumer, opts ...Option) (oci *Receiver, port int, done func()) {
-	ln, err := net.Listen("tcp", "127.0.0.1:")
+	ln, err := net.Listen("tcp", "localhost:")
 	if err != nil {
 		t.Fatalf("Failed to find an available address to run the gRPC server: %v", err)
 	}

--- a/receiver/opencensusreceiver/octrace/opencensus_test.go
+++ b/receiver/opencensusreceiver/octrace/opencensus_test.go
@@ -475,7 +475,7 @@ func (sa *spanAppender) ConsumeTraceData(ctx context.Context, td consumerdata.Tr
 }
 
 func ocReceiverOnGRPCServer(t *testing.T, sr consumer.TraceConsumer, opts ...Option) (oci *Receiver, port int, done func()) {
-	ln, err := net.Listen("tcp", ":0")
+	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("Failed to find an available address to run the gRPC server: %v", err)
 	}

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -99,7 +99,7 @@ func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 		ReceiverSettings: configmodels.ReceiverSettings{
 			TypeVal:  typeStr,
 			NameVal:  typeStr,
-			Endpoint: "127.0.0.1:9090",
+			Endpoint: "localhost:9090",
 		},
 	}
 }

--- a/receiver/zipkinreceiver/config_test.go
+++ b/receiver/zipkinreceiver/config_test.go
@@ -47,7 +47,7 @@ func TestLoadConfig(t *testing.T) {
 			ReceiverSettings: configmodels.ReceiverSettings{
 				TypeVal:  typeStr,
 				NameVal:  "zipkin/customname",
-				Endpoint: "127.0.0.1:8765",
+				Endpoint: "localhost:8765",
 			},
 		})
 }

--- a/receiver/zipkinreceiver/factory.go
+++ b/receiver/zipkinreceiver/factory.go
@@ -31,7 +31,7 @@ const (
 	// The value of "type" key in configuration.
 	typeStr = "zipkin"
 
-	defaultBindEndpoint = "127.0.0.1:9411"
+	defaultBindEndpoint = "localhost:9411"
 )
 
 // Factory is the factory for Zipkin receiver.

--- a/receiver/zipkinreceiver/testdata/config.yaml
+++ b/receiver/zipkinreceiver/testdata/config.yaml
@@ -1,7 +1,7 @@
 receivers:
   zipkin:
   zipkin/customname:
-    endpoint: "127.0.0.1:8765"
+    endpoint: "localhost:8765"
 
 processors:
   exampleprocessor:

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -151,7 +151,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestZipkinReceiverPortAlreadyInUse(t *testing.T) {
-	l, err := net.Listen("tcp", "127.0.0.1:")
+	l, err := net.Listen("tcp", "localhost:")
 	if err != nil {
 		t.Fatalf("failed to open a port: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestZipkinReceiverPortAlreadyInUse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to split listener address: %v", err)
 	}
-	traceReceiver, err := New("127.0.0.1:"+portStr, exportertest.NewNopTraceExporter())
+	traceReceiver, err := New("localhost:"+portStr, exportertest.NewNopTraceExporter())
 	if err != nil {
 		t.Fatalf("Failed to create receiver: %v", err)
 	}
@@ -543,7 +543,7 @@ func TestStartTraceReception(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sink := new(exportertest.SinkTraceExporter)
-			zr, err := New("127.0.0.1:0", sink)
+			zr, err := New("localhost:0", sink)
 			require.Nil(t, err)
 			require.NotNil(t, zr)
 

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -151,7 +151,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestZipkinReceiverPortAlreadyInUse(t *testing.T) {
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", "127.0.0.1:")
 	if err != nil {
 		t.Fatalf("failed to open a port: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestZipkinReceiverPortAlreadyInUse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to split listener address: %v", err)
 	}
-	traceReceiver, err := New(":"+portStr, exportertest.NewNopTraceExporter())
+	traceReceiver, err := New("127.0.0.1:"+portStr, exportertest.NewNopTraceExporter())
 	if err != nil {
 		t.Fatalf("Failed to create receiver: %v", err)
 	}

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -94,7 +94,7 @@ func (mb *MockBackend) Start(backendType BackendType) error {
 
 	switch backendType {
 	case BackendOC:
-		addr := "127.0.0.1:56565"
+		addr := "localhost:56565"
 		mb.ocReceiver, err = opencensusreceiver.New(addr, mb.tc, mb.mc)
 		if err != nil {
 			return err

--- a/testbed/tests/testdata/add-attributes-config.yaml
+++ b/testbed/tests/testdata/add-attributes-config.yaml
@@ -7,7 +7,7 @@ receivers:
 
 exporters:
   opencensus:
-    endpoint: "127.0.0.1:56565"
+    endpoint: "localhost:56565"
 
 processors:
   queued-retry:

--- a/testbed/tests/testdata/agent-config.yaml
+++ b/testbed/tests/testdata/agent-config.yaml
@@ -7,7 +7,7 @@ receivers:
 
 exporters:
   opencensus:
-    endpoint: "127.0.0.1:56565"
+    endpoint: "localhost:56565"
 
 processors:
   queued-retry:

--- a/translator/trace/jaeger/protospan_to_jaegerproto_test.go
+++ b/translator/trace/jaeger/protospan_to_jaegerproto_test.go
@@ -368,7 +368,7 @@ var ocBatches = []consumerdata.TraceData{
 				Attributes: &tracepb.Span_Attributes{
 					AttributeMap: map[string]*tracepb.AttributeValue{
 						"http.url": {
-							Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "http://127.0.0.1:15598/client_transactions"}},
+							Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "http://localhost:15598/client_transactions"}},
 						},
 						"peer.ipv4": {
 							Value: &tracepb.AttributeValue_IntValue{IntValue: 3224716605},

--- a/translator/trace/jaeger/protospan_to_jaegerthrift_test.go
+++ b/translator/trace/jaeger/protospan_to_jaegerthrift_test.go
@@ -422,7 +422,7 @@ var tds = []consumerdata.TraceData{
 				Attributes: &tracepb.Span_Attributes{
 					AttributeMap: map[string]*tracepb.AttributeValue{
 						"http.url": {
-							Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "http://127.0.0.1:15598/client_transactions"}},
+							Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "http://localhost:15598/client_transactions"}},
 						},
 						"peer.ipv4": {
 							Value: &tracepb.AttributeValue_IntValue{IntValue: 3224716605},

--- a/translator/trace/jaeger/testdata/jaegerproto_batch_01.json
+++ b/translator/trace/jaeger/testdata/jaegerproto_batch_01.json
@@ -61,7 +61,7 @@
         {
           "key": "http.url",
           "v_type": 0,
-          "v_str": "http://127.0.0.1:15598/client_transactions"
+          "v_str": "http://localhost:15598/client_transactions"
         },
         {
           "key": "span.kind",

--- a/translator/trace/jaeger/testdata/ocproto_batch_01.json
+++ b/translator/trace/jaeger/testdata/ocproto_batch_01.json
@@ -40,7 +40,7 @@
             "http.url": {
               "Value": {
                 "StringValue": {
-                  "value": "http://127.0.0.1:15598/client_transactions"
+                  "value": "http://localhost:15598/client_transactions"
                 }
               }
             },

--- a/translator/trace/jaeger/testdata/proto_batch_no_binary_tags_01.json
+++ b/translator/trace/jaeger/testdata/proto_batch_no_binary_tags_01.json
@@ -66,7 +66,7 @@
       "tags": [
         {
           "key": "http.url",
-          "v_str": "http://127.0.0.1:15598/client_transactions"
+          "v_str": "http://localhost:15598/client_transactions"
         },
         {
           "key": "span.kind",

--- a/translator/trace/jaeger/testdata/thrift_batch_01.json
+++ b/translator/trace/jaeger/testdata/thrift_batch_01.json
@@ -51,7 +51,7 @@
         {
           "key": "http.url",
           "vType": "STRING",
-          "vStr": "http://127.0.0.1:15598/client_transactions"
+          "vStr": "http://localhost:15598/client_transactions"
         },
         {
           "key": "span.kind",

--- a/translator/trace/jaeger/testdata/thrift_batch_no_binary_tags_01.json
+++ b/translator/trace/jaeger/testdata/thrift_batch_no_binary_tags_01.json
@@ -71,7 +71,7 @@
         {
           "key": "http.url",
           "vType": "STRING",
-          "vStr": "http://127.0.0.1:15598/client_transactions"
+          "vStr": "http://localhost:15598/client_transactions"
         },
         {
           "key": "span.kind",


### PR DESCRIPTION
MacOs users with restricted network configs will get a lot of popups like this:
Do you want the application “healthcheckextension.test” to accept incoming network connections?

This PR reduces the number of popups to only one, which is for healthcheckextension because they use the ":port" address in the net.Listen.